### PR TITLE
Add an alternative way to change paths for after Homebrew installation

### DIFF
--- a/Homebrew/README.md
+++ b/Homebrew/README.md
@@ -15,6 +15,8 @@ One thing we need to do is tell the system to use programs installed by Hombrew 
 
     $ echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
 
+Alternatively, we can also insert `/usr/local/bin` to the first line of `/private/etc/paths` and reboot the Mac to change global paths loading order. Admin password may be required if you modify the file.
+
 Open an new terminal tab with **Cmd+T** (you should also close the old one), then run the following command to make sure everything works:
 
     $ brew doctor


### PR DESCRIPTION
Change path loading order globally by modifying `/private/etc/paths`.