### PR TITLE
fix links not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,8 @@ This book covers the basics of setting up a development environment on a new Mac
 
 [![Screen](https://raw.githubusercontent.com/sb2nov/mac-setup/master/assets/intro.jpeg)](https://raw.githubusercontent.com/sb2nov/mac-setup/master/assets/intro.jpeg)
 
-We will set up [Node][] (JavaScript), [Python][], [CPlusPlus][], and [Ruby][] environments. Even if you don't program in all four, it is good to have them, as many command-line tools use one of them. We also install a few daily use applications and Latex. As you read and follow these steps, feel free to send me any feedback or comments you may have.
+We will set up [Node](http://nodejs.org) (JavaScript), [Python](http://www.python.org), [CPlusPlus](http://www.cplusplus.com), and [Ruby](http://www.ruby-lang.org) environments. Even if you don't program in all four, it is good to have them, as many command-line tools use one of them. We also install a few daily use applications and Latex. As you read and follow these steps, feel free to send me any feedback or comments you may have.
 
 All contributions to the book are welcome. Please help add support for other libraries and languages.
 
 **Note:** This book has been generated using [GitBook](http://www.gitbook.io) and is open source, feel free to contribute or signal issues on [GitHub](https://github.com/sb2nov/mac-setup).
-
-[Node]: http://nodejs.org
-[Python]: http://www.python.org
-[CPlusPlus]: http://www.cplusplus.com
-[Ruby]: http://www.ruby-lang.org


### PR DESCRIPTION
Looks like the markdown engine used for gitbooks doesn't work with the way the links were before.

![screen shot 2015-12-11 at 4 41 39 pm](https://cloud.githubusercontent.com/assets/6525926/11737134/1fa7b5da-a026-11e5-92e9-62e1ed33444c.png)
