### PR TITLE
fix: no prerequisites for iPython installation

### DIFF
--- a/Python/ipython.md
+++ b/Python/ipython.md
@@ -1,6 +1,7 @@
 # IPython
 
 [IPython](http://ipython.org/) is an awesome project which provides a much better Python shell than the one you get from running `$ python` in the command-line. It has many cool functions (running Unix commands from the Python shell, easy copy & paste, creating Matplotlib charts in-line, etc.) and I'll let you refer to the [documentation](http://ipython.org/ipython-doc/stable/index.html) to discover them.
+IPython is a kernal for Jupyter Notebook. If you are confused iPython with Jupyter,  refer to thd [Jupyter documentation](http://jupyter.readthedocs.io/en/latest/ipython/content-ipython.html)
 
 ### Install
 

--- a/Python/ipython.md
+++ b/Python/ipython.md
@@ -4,20 +4,6 @@
 
 ### Install
 
-Before we install IPython, we'll need to get some dependencies. Run the following:
-
-    $ brew update # Always good to do
-    $ brew install zeromq # Necessary for pyzmq
-    $ brew install pyqt # Necessary for the qtconsole
-    $ pip install pyzmq
-    $ pip install pygments
-    $ pip install jinja2
-    $ pip install tornado
-
-It may take a few minutes to build these.
-
-Once it's done, we can install IPython with all the available options:
-
     $ pip install ipython
 
 If you want a more fine grained command you can try the following:


### PR DESCRIPTION
There should be no prerequisites for iPython installation, according to the official site: http://ipython.readthedocs.io/en/stable/install/install.html#installation-using-pip
Especially, web server frameworks and template engines like tornado and jinjia2 should never be the dependency of iPython. I suspect this part is copied from somewhere else that is irrelevant.