### PR TITLE
Fix: Removed .DS_STORE duplicate

### DIFF
--- a/Node.js/README.md
+++ b/Node.js/README.md
@@ -19,6 +19,7 @@ Node modules are installed locally in the `node_modules` folder of each project 
 
 #### Install nodejs
 
+    $ source ~/.bashrc # sources your bashrc to add nvm to path
     $ command -v nvm  # check the nvm use message
     $ nvm install node  # install most recent nodejs stable version
     $ nvm ls  # list installed node version

--- a/SublimeText/Preferences.md
+++ b/SublimeText/Preferences.md
@@ -29,7 +29,6 @@ This is an example of User Settings for a basic development but please feel free
         "*.suo",
         "*.pdb",
         "*.idb",
-        ".DS_Store",
         "*.psd"
     ],
     "font_face": "Source Code Pro",


### PR DESCRIPTION
In [`SublimeText/Preferences.md`](https://github.com/sb2nov/mac-setup/compare/master...snood1205:subl-fix) `.DS_Store` is listed twice. Also I added an explicit command to `source ~/.bashrc` in the `nvm` install.