### PR TITLE
Fix docker-toolbox cask

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -10,7 +10,7 @@ In order to simplify the installation process you should install homebrew-cask w
 
 Use can use cask to install Docker Toolbox which is a collection of useful docker tools such as compose, machine and Kitematic.
 
-    $ brew cask install dockertoolbox
+    $ brew cask install docker-toolbox
 
 ### Quick Start
 


### PR DESCRIPTION
Use 'docker-toolbox' to install using brew cask.