### PR TITLE
Update README.md

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -2,17 +2,30 @@
 
 [Docker](https://docs.docker.com) is a platform for developers and sysadmins to develop, ship, and run applications. Docker lets you quickly assemble applications from components and eliminates the friction that can come when shipping code. Docker lets you get your code tested and deployed into production as fast as possible.
 
-### Before you start
+### Docker for Mac 
+Docker for Mac is the current release of Docker for OSX. Requirements:
+* Mac must be 2010 or new model with Intel's hardare support for memory management unit (MMU, virtualization, and Unrestricted mode.
+* OSX El Capital 10.11 and newer releases are supported. 
+* Virtualbox prior to version 4.3.30 must NOT be installed. It is incompatiable. Use a newer version.
+
+###Install Docker for Mac
+Docker for Mac can be downloaded  [here](httpsL//https://docs.docker.com/docker-for-mac/install/).
+
+###Docker Toolbox###
+Docker Toolbox is a legacy desktop solution for older Mac and Windows systems that do not meet the requirements of [Docker for Mac](https://docs.docker.com/docker-for-mac/) and Docker for Windows.
+
+
+### Before you install Docker Toolbox
 
 In order to simplify the installation process you should install homebrew-cask which provides a friendly homebrew-style CLI workflow for the administration of Mac applications distributed as binaries. Refer to [this](../Homebrew/Cask.md) article in order to install homebrew-cask.
 
-### Install
+### Install Docker Toolbox
 
 Use can use cask to install Docker Toolbox which is a collection of useful docker tools such as compose, machine and Kitematic.
 
     $ brew cask install docker-toolbox
 
-### Quick Start
+### Docker Toolbox Quick Start
 
 For quick start find the Docker Quickstart Terminal and double click to launch it. Then you start the hello world container using:
 


### PR DESCRIPTION
Updating the Docker Readme. It is outdated and refers to Docker Toolkbox, which is only for legacy support of older systems that don't support Docker for Mac. I could not find a cask for installation of Docker for Mac, so linked directly to the Docker website for Docker for Mac for installation.

I left the older Docker Toolbox information in place for systems that don't meet the requirements of Docker for Mac, just edited the heading to differentiate it from Docker for Mac.