### PR TITLE
Add section on tree command

### DIFF
--- a/Tree/README.md
+++ b/Tree/README.md
@@ -1,0 +1,58 @@
+# Tree
+
+Tree is a recursive directory listing command that produces a depth indented listing of files.
+
+## Usage
+Running `tree` will produce output like this:
+
+```bash
+.
+├── Apps
+│   ├── Octave.md
+│   ├── README.md
+│   ├── Settings.md
+│   ├── araxis-merge.jpg
+│   ├── beyond-compare.png
+│   ├── delta-walker.jpg
+│   ├── filemerge.png
+│   └── kaleidoscope.png
+├── CONTRIBUTING.md
+├── Cpp
+│   └── README.md
+├── Docker
+│   └── README.md
+├── Git
+│   ├── README.md
+│   └── gitignore.md
+└── Go
+    └── README.md
+
+5 directories, 14 files
+```
+
+To limit the recursion you can pass an `-L` flag and specify the maximum depth `tree` will use when searching.
+
+```bash
+tree -L 1
+```
+will output:
+
+```bash
+.
+├── Apps
+├── CONTRIBUTING.md
+├── Cpp
+├── Docker
+├── Git
+└── Go
+
+5 directories, 1 files
+```
+
+## Installation
+
+To install the latest version, use homebrew:
+
+```bash
+brew install tree
+```


### PR DESCRIPTION
Add own section on `tree` command. I was not sure if it deserves it's own section, but I could not find a more appropriate place to put it. Maybe in the future, a collection of these "smaller" commands could be put under a single section.

Referencing #116.