### PR TITLE
Introduce Makefile with deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: deploy
+.PHONY: deploy serve
 
 deploy:
 	sh ./scripts/publish_gitbook.sh
+
+serve:
+	gitbook serve

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: deploy
+
+deploy:
+	sh ./scripts/publish_gitbook.sh

--- a/scripts/publish_gitbook.sh
+++ b/scripts/publish_gitbook.sh
@@ -13,7 +13,7 @@ for cmd in ${commands[@]}; do is_available "$cmd"; done
 echo "All required packages are available, will continue"
 
 echo "Updating list of contributors"
-python contributors.py
+python ./scripts/contributors.py
 git commit -a -m "Update list of contributors"
 git push origin master
 echo "Finished updating list of contributors"


### PR DESCRIPTION
I'd like to propose we use a Makefile, this makes it easy to configure commands which can be all run from the root folder. No need to remember where any script is located, just run `make deploy` from the root folder. We started using this in my team at work a while back and it made things a lot easier. As you can see it's minimal configuration and it's an old convention a lot of people use.

What do you guys think?