### PR TITLE
Add JAVA_HOME setup command for Java9

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -21,7 +21,7 @@ Add `JAVA_HOME` to your environment variables by adding the line below to your `
 
     export JAVA_HOME="`/usr/libexec/java_home -v 1.8`"
 
-Are you Java9 user? Use below instead of above.
+If you are using Java 9, use the following:
 
     export JAVA_HOME="`/usr/libexec/java_home -v 9`"
 

--- a/Java/README.md
+++ b/Java/README.md
@@ -21,4 +21,8 @@ Add `JAVA_HOME` to your environment variables by adding the line below to your `
 
     export JAVA_HOME="`/usr/libexec/java_home -v 1.8`"
 
+Are you Java9 user? Use below instead of above.
+
+    export JAVA_HOME="`/usr/libexec/java_home -v 9`"
+
 You should have Java working now. Two popular IDE alternatives for writing Java are [Eclipse](https://www.eclipse.org/downloads/) or [IntelliJ](https://www.jetbrains.com/idea/download/).


### PR DESCRIPTION
Java 9 changes the parameter format for `java_home`.