### PR TITLE
add missing step to rust readme

### DIFF
--- a/Rust/README.md
+++ b/Rust/README.md
@@ -10,6 +10,12 @@ anything additional.
 $ brew install rustup
 ```
 
+Use rustup to install the Rust compiler (rustc) and the Rust package manager (cargo).
+
+```sh
+$ rustup-init
+```
+
 To verify you can run:
 
 ```sh
@@ -17,4 +23,3 @@ $ rustc --version
 ```
 
 [The official documentation on how to install Rust](https://www.rust-lang.org/en-US/install.html).
-


### PR DESCRIPTION
There was a step missing to the Rust installation guide.