### PR TITLE
Fix incorrect alias

### DIFF
--- a/iTerm/zsh.md
+++ b/iTerm/zsh.md
@@ -170,5 +170,5 @@ function mkcd() { mkdir -p "$@" && cd "$_"; }
 
 # Example aliases
 alias cppcompile='c++ -std=c++11 -stdlib=libc++'
-alias git='g'
+alias g='git'
 ```


### PR DESCRIPTION
In the `env.sh` example, the alias is incorrectly set as `alias git='g'` while it should be the other way around, the correct version being `alias g='git'`.