### PR TITLE
update install command for heroku

### DIFF
--- a/Heroku/README.md
+++ b/Heroku/README.md
@@ -6,7 +6,7 @@
 
 Assuming that you have an Heroku account ([sign up](https://signup.heroku.com) if you don't), let's install the [Heroku Client](https://devcenter.heroku.com/articles/using-the-cli) for the command-line using Homebrew.
 
-    $ brew install heroku-toolbelt
+    $ brew install heroku/brew/heroku
 
 The formula might not have the latest version of the Heroku Client, which is updated pretty often. Let's update it now:
 


### PR DESCRIPTION
Looks like `$ brew install heroku-toolbelt` throws an error now. 

Heroku docs suggest `$ brew install heroku/brew/heroku`

Error: No available formula with the name "homebrew/core/heroku"
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.