### PR TITLE
Add note about unsupported MySQL version by Sequel Pro

### DIFF
--- a/MyySQL/README.md
+++ b/MyySQL/README.md
@@ -4,29 +4,31 @@
 
 We will install [MySQL](http://www.mysql.com/) using Homebrew, which will also install some header files needed for MySQL bindings in different programming languages (MySQL-Python for one).
 
-    $ brew install mysql
+> **Note**: Sequel Pro does not support latest MySQL (version 8), because of that you may want to install MySQL 5.7 instead - `brew install mysql@5.7`.
+
+    brew install mysql
 
 ## Usage
 
 To have launchd start MySQL now and restart at login:
 
-    $ brew services start mysql
+    brew services start mysql
 
 Or, if you don't want/need a background service you can just use the `mysql.server` tool:
 
-    $ mysql.server start
+    mysql.server start
 
 To stop it when you are done, run:
 
-    $ mysql.server stop
+    mysql.server stop
 
 You can see the different commands available for `mysql.server` with:
 
-    $ mysql.server --help
+    mysql.server --help
 
 To connect with the command-line client, run:
 
-    $ mysql -uroot
+    mysql -uroot
 
 (Use `exit` to quit the MySQL shell)
 
@@ -38,4 +40,4 @@ It is always nice to have a GUI tool for managing databases. For Mac, you can us
 
 You may install Sequel Pro using [homebrew](http://sourabhbajaj.com/mac-setup/Homebrew/Cask.html):
 
-    $ brew cask install sequel-pro
+    brew cask install sequel-pro


### PR DESCRIPTION
I added the note right in the first mention of `brew install` so end-user does not have to *reinstall* the MySQL if he/she wants to use Sequel Pro.

https://github.com/sequelpro/sequelpro/issues/2699