### PR TITLE
Capitalize GitHub and GitBook per their brands' styling

### DIFF
--- a/Apps/Settings.md
+++ b/Apps/Settings.md
@@ -20,7 +20,7 @@ These settings are optional. Some of them are highly subjective and should not b
 ## Notebooks
 
 - Set the default directory to a folder inside Dropbox for CloudSync
-- Overwrite one of the themes in the app with [Github Mardown CSS](https://gist.github.com/andyferra/2554919)
+- Overwrite one of the themes in the app with [GitHub Mardown CSS](https://gist.github.com/andyferra/2554919)
 
 ## Spectacle
 

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,6 +1,6 @@
 # Contributors
 
-Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [Github Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
+Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [GitHub Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
 
 - [sb2nov](https://github.com/sb2nov)
 - [simeg](https://github.com/simeg)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 
 serve:
 ifndef GITBOOK
-	$(error "Gitbook is not available, please run 'make install' first")
+	$(error "GitBook is not available, please run 'make install' first")
 else
 	$(GITBOOK) serve
 endif

--- a/References/README.md
+++ b/References/README.md
@@ -3,8 +3,8 @@
 Thank you for all the awesome pages and documentation below that helped set this up.
 
 - [Nicolashery](https://github.com/nicolashery/mac-dev-setup)
-- [Github](https://help.github.com/articles)
-- [Gitbook](https://github.com/GitbookIO/gitbook)
+- [GitHub](https://help.github.com/articles)
+- [GitBook](https://github.com/GitbookIO/gitbook)
 - [Sublime Plugins](https://sublime.wbond.net/)
 - [Scala IDE Documentation](http://scala-ide.org/docs/user/gettingstarted.html)
 

--- a/scripts/contributors.py
+++ b/scripts/contributors.py
@@ -8,7 +8,7 @@ import urllib2
 
 HEADER = """# Contributors
 
-Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [Github Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
+Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [GitHub Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
 
 """
 


### PR DESCRIPTION
This is just a suggestion for a trivial styling change. "GitHub" and "GitBook" style their names with internal capitals. This PR changes mentions of them in the book to match their preferred styling.