### PR TITLE
Update Homebrew instructions for Mojave and some other tweaks

### DIFF
--- a/Homebrew/README.md
+++ b/Homebrew/README.md
@@ -5,28 +5,42 @@ macOS_ and is an essential tool for any developer.
 
 ## Installation
 
-Before you can run Homebrew you need to have the **Command Line Tools** for
-**Xcode** installed. It include compilers that will allow you to build things
-from source, and if you are missing this it's available through the App Store >
-Updates.
+Before you can run Homebrew you need to have the **Command Line Tools for
+Xcode** installed. It include compilers and other tools that will allow you
+to build things from source, and if you are missing this it's available
+through the App Store > Updates. You can also install it from the terminal
+by running the following:
 
-To install Homebrew run the following:
-terminal, hit **Enter**, and follow the steps on the screen:
+    $ sudo xcode-select --install
+
+To install Homebrew run the following in a terminal, hit **Enter**, and follow
+the steps on the screen:
 
     $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-One thing you need to do is tell the system to use programs installed by Hombrew
-(in `/usr/local/bin`) rather than the OS default if it exists. You do this by
-adding `/usr/local/bin` to your `PATH` environment variable (if you're using
-`zsh` you should use `.zshrc` instead of `.bash_profile`):
+### Setting up your `PATH`
 
-    $ echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+To make the Homebrew-installed programs available in your shell, you need to add
+your Homebrew installation location to your `$PATH`. This is done for you already on
+macOS 10.14 Mojave and newer. For older versions of macOS, do the following:
 
-Alternatively, you can also insert `/usr/local/bin` to the first line of
-`/private/etc/paths` and reboot the Mac to change global paths loading order.
-Admin password may be required if you modify the file.
+You change your path by adding `/usr/local/bin` to your `PATH` environment variable.
+This can be done on a per-user basis by adjusting `PATH` in your `~/.bash_profile`.
+To do this, run:
 
-To be able to use `brew` you need to start a new terminal session. After that
+    $ echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+
+(If you're using `zsh`, you should do this for `~/.zshrc` in addition to
+`~/.bash_profile`.)
+
+Alternatively, you can also insert `/usr/local/bin` before the first line of
+`/etc/paths` to change the global default paths order, for all users and all
+major shells. An admin password will be required if you modify the file.
+
+Then, to be able to use `brew` you need to start a new terminal session. After that
 you should make sure everything is working by running:
 
     $ brew doctor
+
+If everything is good, you should see no warnings, and a message that you are
+"ready to brew!".


### PR DESCRIPTION
This PR revises the Homebrew installation instructions to update them for Mojave and newer versions of macOS, and do some other tweaks.

Changes:

* `/usr/local/bin` is on the `$PATH` by default now in newer versions of macOS. (It's in `/etc/paths`.) This PR edits the instructions to tell you to only do the path changes if you're on an older OS.
* `/etc` is the more typical path to use for fiddling with the `/etc` files, I think, not `/private/etc`. `/etc` is the same location that other Unixes use; I don't think there's any reason to expose users to the details of `/private`.
* `$PATH` is already exported; there's no need to add an `export` statement when you're changing its values
* Added the command-line technique for installing the Xcode CLT
* I changed the `zsh` instructions to say "in addition to ~/.bashrc" instead of "instead of ~/.bashrc". Even if your primary shell is zsh, you'll sometimes find yourself in bash (especially if you're doing scripting), so you want the Homebrewed stuff available in bash too, even if you're a Zsh-er (like me)
* A couple grammar tweaks
* The "for" is part of the official name for for the “Command Line Tools for Xcode”, so I changed the highlighting there.
* Added instructions for how to actually edit `/etc/paths` as admin