### PR TITLE
Fix URL for the_silver_searcher in iterm/ack/alts

### DIFF
--- a/iTerm/ack.md
+++ b/iTerm/ack.md
@@ -65,5 +65,5 @@ $ ack --dump
 
 ## Alternatives to `ack`
 
-There's [The Silver Surfer](The Silver Searcher) which describes itself as a
+There's [The Silver Surfer](https://github.com/ggreer/the_silver_searcher) which describes itself as a
 > A code searching tool similar to `ack`, with a focus on speed.


### PR DESCRIPTION
I got a 404 for the current link. The section may have been removed, so just linked to the repo.