### PR TITLE
Updates brew install command for source-code-pro

### DIFF
--- a/iTerm/README.md
+++ b/iTerm/README.md
@@ -18,7 +18,7 @@ Here are some suggested settings you can change or set, **they are all optional*
 - Go to profiles -> Default -> Terminal -> Check silence bell to disable the terminal session from making any sound
 - Download [one of iTerm2 color schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/schemes) and then set these to your default profile colors
 - Change the cursor text and cursor color to yellow make it more visible
-- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](https://sourabhbajaj.com/mac-setup/Homebrew/) `brew tap caskroom/fonts && brew cask install font-source-code-pro`
+- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](https://sourabhbajaj.com/mac-setup/Homebrew/) `brew tap homebrew/cask-fonts && brew cask install font-source-code-pro`
 - If you're using BASH instead of ZSH you can add `export CLICOLOR=1` line to your `~/.bash_profile` file for nice coloring of listings
 
 [![Screen](https://raw.githubusercontent.com/sb2nov/mac-setup/master/assets/Iterm.png)](https://raw.githubusercontent.com/sb2nov/mac-setup/master/assets/Iterm.png)


### PR DESCRIPTION
The current instructions to install source-code-pro was throwing an error:

```Error: caskroom/fonts was moved. Tap homebrew/cask-fonts instead.```

This PR fixes that. 