### PR TITLE
Fix suggested Oh My Zsh plugins

### DIFF
--- a/iTerm/zsh.md
+++ b/iTerm/zsh.md
@@ -61,7 +61,7 @@ Add plugins to your shell by adding the name of the plugin to the `plugin`
 array in your `.zshrc`.
 
 ```sh
-plugins=(git colored-man colorize pip python brew osx zsh-syntax-highlighting zsh-autosuggestions)
+plugins=(git colored-man-pages colorize pip python brew osx zsh-syntax-highlighting zsh-autosuggestions)
 ```
 
 You'll find a list of all plugins on the [Oh My Zsh Wiki](https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins).


### PR DESCRIPTION
Oh My Zsh plugin `colored-man` was renamed `colored-man-pages` upstream: https://github.com/ohmyzsh/ohmyzsh/commit/bb509dda236f8ed04b90806bc66f4ad1a41f57bc#diff-e0daa4091e1fc25d3c2ff19ed4613612

As a result, if you copy & paste the plugin list supplied, you end up with an error saying `colored-man` is not found. This PR corrects that.