### PR TITLE
Don't use terminal prompt for single line commands

### DIFF
--- a/Apps/Octave.md
+++ b/Apps/Octave.md
@@ -15,8 +15,8 @@ As this distributes a compiled version of Octave, installation will be much fast
 
 To [install using homebrew-cask](https://octave-app.org/#installing-with-homebrew-cask) run:
 
-    $ brew tap octave-app/octave-app
-    $ brew cask install octave-app
+    brew tap octave-app/octave-app
+    brew cask install octave-app
 
 ### Homebrew official
 
@@ -24,15 +24,15 @@ You can also install Octave from the official Homebrew source using the method b
 
 Install `octave` from core Homebrew (which is available by default):
 
-    $ brew install octave
+    brew install octave
 
 **Note**: If `brew` complains about not having a formula for Octave, the following command should fix it:
 
-    $ brew tap --repair
+    brew tap --repair
 
 The command below upgrades Octave and its dependencies to the latest Homebrew-supported versions:
 
-    $ brew update && brew upgrade
+    brew update && brew upgrade
 
 Octave has many dependencies which will be downloaded and installed prior to Octave. **The entire installation process can take a few hours if you are compiling from source.**
 

--- a/BashCompletion/README.md
+++ b/BashCompletion/README.md
@@ -7,7 +7,7 @@ key. This will help you when writing the bash command in terminal.
 ## Installation
 
 ```bash
-$ brew install bash-completion
+brew install bash-completion
 ```
 
 Bash completion will be installed in `/usr/local/etc/bash_completion.d`.
@@ -21,13 +21,13 @@ For it to work, add this to your `~/.bash_profile`:
 Or simply type:
 
 ```bash
-$ echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> ~/.bash_profile
+echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> ~/.bash_profile
 ```
 
 Restart your bash session:
 
 ```bash
-$ source ~/.bash_profile
+source ~/.bash_profile
 ```
 
 ## Usage
@@ -49,13 +49,13 @@ bisect         cherry         commit         fetch          grep           log  
 You can list additional completion packages are available by typing:
 
 ```bash
-$ brew search completion
+brew search completion
 ```
 
 And you can install them using `brew install` commands, for example:
 
 ```bash
-$ brew install docker-completion
+brew install docker-completion
 ```
 
 *You can also manually add a bash completion file into

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -22,12 +22,12 @@ You'll need `homebrew-cask` to install Docker Toolbox, if you don't have it refe
 
 ### Installation
 
-    $ brew cask install docker-toolbox
+    brew cask install docker-toolbox
 
 ### Quick Start
 
 For quick start find the newly installed _Docker Quickstart Terminal_ and double-click to launch it. Then you can start the _Hello World container_ using:
 
-    $ docker run hello-world
+    docker run hello-world
 
 You can find more about Docker in the [documentation](https://docs.docker.com/).

--- a/Git/README.md
+++ b/Git/README.md
@@ -2,11 +2,11 @@
 
 What's a developer without [Git](http://git-scm.com/)? To install, run:
 
-    $ brew install git
+    brew install git
 
 When done, to test that it installed properly you can run:
 
-    $ git --version
+    git --version
 
 And `which git` should output `/usr/local/bin/git`.
 
@@ -14,8 +14,8 @@ Next, we'll define your Git user (should be the same name and email you use for
 [GitHub](https://github.com/)):
 
 ```sh
-$ git config --global user.name "Your Name Here"
-$ git config --global user.email "your_email@youremail.com"
+git config --global user.name "Your Name Here"
+git config --global user.email "your_email@youremail.com"
 ```
 
 They will get added to your `.gitconfig` file.
@@ -26,7 +26,7 @@ password every time you push a commit you can cache your credentials by running
 the following command, as described in the
 [instructions](https://help.github.com/articles/caching-your-github-password-in-git/).
 
-    $ git config --global credential.helper osxkeychain
+    git config --global credential.helper osxkeychain
 
 ## SSH Config for GitHub
 
@@ -39,7 +39,7 @@ First, we need to check for existing SSH keys on your computer. We do this by
 running:
 
 ```sh
-$ ls -al ~/.ssh
+ls -al ~/.ssh
 # Lists the files in your .ssh directory, if they exist
 ```
 
@@ -55,7 +55,7 @@ email. The default settings are preferred, so when you're asked to "enter a
 file in which to save the key,"" just press Enter to continue.
 
 ```sh
-$ ssh-keygen -t rsa -C "your_email@example.com"
+ssh-keygen -t rsa -C "your_email@example.com"
 # Creates a new ssh key, using the provided email as a label
 ```
 
@@ -64,7 +64,7 @@ $ ssh-keygen -t rsa -C "your_email@example.com"
 Run the following commands to add your SSH key to the `ssh-agent`.
 
 ```sh
-$ eval "$(ssh-agent -s)"
+eval "$(ssh-agent -s)"
 ```
 
 If you're running macOS Sierra 10.12.2 or later, you will need to modify your
@@ -82,7 +82,7 @@ No matter what operating system version you run you need to run this command to
 complete this step:
 
 ```sh
-$ ssh-add -K ~/.ssh/id_rsa
+ssh-add -K ~/.ssh/id_rsa
 ```
 
 ### Adding a new SSH key to your GitHub account
@@ -90,7 +90,7 @@ $ ssh-add -K ~/.ssh/id_rsa
 The last step is to let GitHub know about your SSH key. Run this command to copy your key to your clipboard:
 
 ```sh
-$ pbcopy < ~/.ssh/id_rsa.pub
+pbcopy < ~/.ssh/id_rsa.pub
 ```
 
 Then go to GitHub and [input your new SSH

--- a/Git/gitignore.md
+++ b/Git/gitignore.md
@@ -29,7 +29,7 @@ node_modules
 
 followed by running the command below, in terminal:
 
-    $ git config --global core.excludesfile ~/.gitignore
+    git config --global core.excludesfile ~/.gitignore
 
 to not track files that are almost always ignored in all Git repositories.
 

--- a/Heroku/README.md
+++ b/Heroku/README.md
@@ -6,11 +6,11 @@
 
 Assuming that you have an Heroku account ([sign up](https://signup.heroku.com) if you don't), let's install the [Heroku Client](https://devcenter.heroku.com/articles/using-the-cli) for the command-line using Homebrew.
 
-    $ brew install heroku/brew/heroku
+    brew install heroku/brew/heroku
 
 The formula might not have the latest version of the Heroku Client, which is updated pretty often. Let's update it now:
 
-    $ heroku update
+    heroku update
 
 Don't be afraid to run `heroku update` every now and then to always have the most recent version.
 
@@ -18,18 +18,18 @@ Don't be afraid to run `heroku update` every now and then to always have the mos
 
 Login to your Heroku account using your email and password:
 
-    $ heroku login
+    heroku login
 
 If this is a new account, and since you don't already have a public **SSH key** in your `~/.ssh` directory, it will offer to create one for you. It will also upload the key to your Heroku account, which will allow you to deploy apps from this computer.
 
 If it didn't offer create the SSH key for you (i.e. your Heroku account already has SSH keys associated with it), you can do so manually by running:
 
-     $ mkdir ~/.ssh
-     $ ssh-keygen -t rsa
+     mkdir ~/.ssh
+     ssh-keygen -t rsa
 
 Keep the default file name and skip the passphrase by just hitting Enter both times. Then, add the key to your Heroku account:
 
-    $ heroku keys:add
+    heroku keys:add
 
 ## Usage
 
@@ -37,10 +37,10 @@ Once your keys are in place and you are authorized, you're ready to deploy apps.
 
 A cheat sheet for deployment:
 
-    $ cd myapp/
-    $ heroku create myapp
-    $ git push heroku master
-    $ heroku ps
-    $ heroku logs -t
+    cd myapp/
+    heroku create myapp
+    git push heroku master
+    heroku ps
+    heroku logs -t
 
 The [Heroku Dev Center](https://devcenter.heroku.com/) is where you will find more information.

--- a/Homebrew/Cask.md
+++ b/Homebrew/Cask.md
@@ -10,14 +10,14 @@ downloading `.dmg` files and dragging them to your Applications folder!
 You need Homebrew on your system to use Cask, and you make Cask available by
 adding it as a tap:
 
-    $ brew tap caskroom/cask
+    brew tap caskroom/cask
 
 ## Search
 
 To see if an app is available on Cask you can search on the [official Cask
 website](https://caskroom.github.io/). You can also search in your terminal:
 
-    $ brew search <package>
+    brew search <package>
 
 ## Example Applications
 
@@ -29,7 +29,7 @@ includes features like syntax highlighting, Markdown rendering, preview of
 JSON, patch files, CSV, ZIP files and more.
 
 ```sh
-$ brew cask install \
+brew cask install \
     qlcolorcode \
     qlstephen \
     qlmarkdown \
@@ -46,7 +46,7 @@ $ brew cask install \
 Here are some useful apps that are available on Cask.
 
 ```sh
-$ brew cask install \
+brew cask install \
     alfred \
     android-file-transfer \
     appcleaner \

--- a/Homebrew/README.md
+++ b/Homebrew/README.md
@@ -11,12 +11,12 @@ to build things from source, and if you are missing this it's available
 through the App Store > Updates. You can also install it from the terminal
 by running the following:
 
-    $ sudo xcode-select --install
+    sudo xcode-select --install
 
 To install Homebrew run the following in a terminal, hit **Enter**, and follow
 the steps on the screen:
 
-    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 ### Setting up your `PATH`
 
@@ -28,7 +28,7 @@ You change your path by adding `/usr/local/bin` to your `PATH` environment varia
 This can be done on a per-user basis by adjusting `PATH` in your `~/.bash_profile`.
 To do this, run:
 
-    $ echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+    echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
 
 (If you're using `zsh`, you should do this for `~/.zshrc` in addition to
 `~/.bash_profile`.)
@@ -40,7 +40,7 @@ major shells. An admin password will be required if you modify the file.
 Then, to be able to use `brew` you need to start a new terminal session. After that
 you should make sure everything is working by running:
 
-    $ brew doctor
+    brew doctor
 
 If everything is good, you should see no warnings, and a message that you are
 "ready to brew!".

--- a/Homebrew/Usage.md
+++ b/Homebrew/Usage.md
@@ -2,50 +2,50 @@
 
 To install a package (or **Formula** in Homebrew vocabulary) simply type:
 
-    $ brew install <formula>
+    brew install <formula>
 
 To update Homebrew's directory of formulae, run:
 
-    $ brew update
+    brew update
 
 **Note**: If that command fails you can manually download the directory of
 formulas like this:
 
-    $ cd /usr/local/Homebrew/
-    $ git fetch origin
-    $ git reset --hard origin/master
+    cd /usr/local/Homebrew/
+    git fetch origin
+    git reset --hard origin/master
 
 To see if any of your formulas need to be updated:
 
-    $ brew outdated
+    brew outdated
 
 To update a formula:
 
-    $ brew upgrade <formula>
+    brew upgrade <formula>
 
 Homebrew keeps older versions of formulas installed on your system, in case you
 want to roll back to an older version. That rarely is necessary, so you can do
 some cleanup to get rid of those old versions:
 
-    $ brew cleanup
+    brew cleanup
 
 If you want to see what formulas Homebrew would delete _without actually
 deleting them_, you can run:
 
-    $ brew cleanup --dry-run
+    brew cleanup --dry-run
 
 To see what you have installed (with their version numbers):
 
-    $ brew list --versions
+    brew list --versions
 
 To search for formulas you run:
 
-    $ brew search <formula>
+    brew search <formula>
 
 To get more information about a formula you run:
 
-    $ brew info <formula>
+    brew info <formula>
 
 To uninstall a formula you can run:
 
-    $ brew uninstall <formula>
+    brew uninstall <formula>

--- a/Java/README.md
+++ b/Java/README.md
@@ -4,7 +4,7 @@
 
 First you should check if Java is already installed
 
-    $ java -version
+    java -version
 
 If you see an output like below then Java is already installed on your machine so skip to _Add Java to PATH_.
 

--- a/MyySQL/README.md
+++ b/MyySQL/README.md
@@ -32,7 +32,7 @@ To connect with the command-line client, run:
 
 (Use `exit` to quit the MySQL shell)
 
-**Note**: By default, the MySQL user `root` has no password. It doesn't really matter for a local development database. If you wish to change it though, you can use `$ mysqladmin -u root password 'new-password'`.
+**Note**: By default, the MySQL user `root` has no password. It doesn't really matter for a local development database. If you wish to change it though, you can use `mysqladmin -u root password 'new-password'`.
 
 ## GUI Tool
 

--- a/Node.js/README.md
+++ b/Node.js/README.md
@@ -6,23 +6,23 @@ Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine.
 
 ### Using Homebrew
 
-    $ brew install node
+    brew install node
 
 ### Using Node Version Manager (nvm)
 
 Download and install [nvm](https://github.com/creationix/nvm) by running:
 
-    $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash
 
 Then download Node and select your version by running:
 
-    $ source ~/.bashrc        # source your bashrc/zshrc to add nvm to PATH
-    $ command -v nvm          # check the nvm use message
-    $ nvm install node        # install most recent Node stable version
-    $ nvm ls                  # list installed Node version
-    $ nvm use node            # use stable as current version
-    $ nvm ls-remote           # list all the Node versions you can install
-    $ nvm alias default node  # set the installed stable version as the default Node
+    source ~/.bashrc        # source your bashrc/zshrc to add nvm to PATH
+    command -v nvm          # check the nvm use message
+    nvm install node        # install most recent Node stable version
+    nvm ls                  # list installed Node version
+    nvm use node            # use stable as current version
+    nvm ls-remote           # list all the Node versions you can install
+    nvm alias default node  # set the installed stable version as the default Node
 
 See the [documentation](https://github.com/creationix/nvm#installation) for information.
 
@@ -30,25 +30,25 @@ See the [documentation](https://github.com/creationix/nvm#installation) for info
 
 To install a package:
 
-    $ npm install <package> # Install locally
-    $ npm install -g <package> # Install globally
+    npm install <package> # Install locally
+    npm install -g <package> # Install globally
 
 To install a package and save it in your project's `package.json` file:
 
-    $ npm install <package> --save
+    npm install <package> --save
 
 To see what's installed:
 
-    $ npm list [-g]
+    npm list [-g]
 
 To find outdated packages:
 
-    $ npm outdated [-g]
+    npm outdated [-g]
 
 To upgrade all or a particular package:
 
-    $ npm update [-g] [<package>]
+    npm update [-g] [<package>]
 
 To uninstall a package:
 
-    $ npm uninstall [-g] <package>
+    npm uninstall [-g] <package>

--- a/Perl/README.md
+++ b/Perl/README.md
@@ -16,38 +16,38 @@ is [cpanminus](https://metacpan.org/pod/App::cpanminus) (`cpanm`).
 ### Homebrew
 
 ```bash
-$ brew install perl cpanminus
+brew install perl cpanminus
 ```
 
 ### Perlbrew
 
 ```bash
-$ curl -L https://install.perlbrew.pl | bash
+curl -L https://install.perlbrew.pl | bash
 
-$ source ~/perl5/perlbrew/etc/bashrc
-$ perlbrew install-cpanm
-$ perlbrew install --switch stable
+source ~/perl5/perlbrew/etc/bashrc
+perlbrew install-cpanm
+perlbrew install --switch stable
 
-$ echo source ~/perl5/perlbrew/etc/bashrc >> ~/.bash_profile
+echo source ~/perl5/perlbrew/etc/bashrc >> ~/.bash_profile
 ```
 
 Other useful commands:
 
 ```bash
 # full documentation
-$ perlbrew help
+perlbrew help
 
 # override version in current shell
-$ perlbrew use $version
+perlbrew use $version
 
 # execute a script with a specific version
-$ perlbrew exec $version $script
+perlbrew exec $version $script
 
 # revert to vendor/Homebrew Perl in current shell
-$ perlbrew off
+perlbrew off
 
 # reinstall all modules in a different version
-$ perlbrew clone-modules $from $to
+perlbrew clone-modules $from $to
 ```
 
 ## Usage
@@ -55,7 +55,7 @@ $ perlbrew clone-modules $from $to
 To install additional modules from [CPAN](https://www.cpan.org):
 
 ```bash
-$ cpanm Modern::Perl
+cpanm Modern::Perl
 ```
 
 ## Customization

--- a/PostgreSQL/README.md
+++ b/PostgreSQL/README.md
@@ -4,41 +4,41 @@ PostgreSQL is an open source relational database management system (RDBMS). It i
 
 ## Installation
 
-    $ brew install postgres
+    brew install postgres
 
   After this, we can test the installation status by checking the version of installed PostgreSQL
 
-    $ postgres -V
+    postgres -V
 
 ## Usage
 
 ### Start PostgreSQL server
 
-    $ pg_ctl -D /usr/local/var/postgres start
+    pg_ctl -D /usr/local/var/postgres start
 
   Or you can start the PostgreSQL server and have it start up at login automatically
 
-    $ brew services start postgresql
+    brew services start postgresql
 
 ### Stop PostgreSQL server
 
-    $ pg_ctl -D /usr/local/var/postgres stop
+    pg_ctl -D /usr/local/var/postgres stop
 
   To make it stop starting up automatically at login
 
-    $ brew services stop postgresql
+    brew services stop postgresql
 
 ### Restart PostgreSQL server
 
-    $ pg_ctl -D /usr/local/var/postgres restart
+    pg_ctl -D /usr/local/var/postgres restart
 
   Or if you're using `homebrew`
 
-    $ brew services restart postgresql
+    brew services restart postgresql
 
 ### Start PostgreSQL console
 
-    $ psql
+    psql
 
 ### GUI tool
 
@@ -46,4 +46,4 @@ PostgreSQL is an open source relational database management system (RDBMS). It i
 
   Install `psequel` using `homebrew` and `cask`
 
-    $ brew cask install psequel
+    brew cask install psequel

--- a/Python/README.md
+++ b/Python/README.md
@@ -15,18 +15,18 @@ to install Python 2.7 you'll have to be explicit about it.
 
 #### Python 3
 
-    $ brew install python
+    brew install python
 
 #### Python 2.7
 
-    $ brew install python@2
+    brew install python@2
 
 Installing Python also installs [pip](https://pypi.org/project/setuptools/)
 (and its dependency [Setuptools](https://pypi.python.org/pypi/setuptools)),
 which is the package manager for Python. Let's upgrade them both:
 
-    $ pip install --upgrade setuptools
-    $ pip install --upgrade pip
+    pip install --upgrade setuptools
+    pip install --upgrade pip
 
 Executable scripts from Python packages you install will be put in
 `/usr/local/share/python`, make sure it's on your `PATH`.
@@ -37,33 +37,33 @@ Executable scripts from Python packages you install will be put in
 manage and install different versions of Python. Works very much like `rbenv`
 for Ruby. First, we must install `pyenv` using Homebrew:
 
-    $ brew install pyenv
+    brew install pyenv
 
 To upgrade `pyenv` in the future, use `upgrade` instead of `install`. After
 installing, add `pyenv init` to your shell to enable shims and autocompletion
 (use `.zshrc` if you're using `zsh`).
 
-    $ echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+    echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
 
 Restart your shell so the path changes take effect.
 
-    $ exec $SHELL
+    exec $SHELL
 
 You can now begin using `pyenv`. To list the all available versions of Python,
 including Anaconda, Jython, PyPy and Stackless, use:
 
-    $ pyenv install --list
+    pyenv install --list
 
 Then install the desired versions:
 
-    $ pyenv install 2.7.12
-    $ pyenv install 3.5.2
+    pyenv install 2.7.12
+    pyenv install 3.5.2
 
 Use the `global` command to set global version(s) of Python to be used in all
 shells. For example, if you prefer 2.7.12 over 3.5.2:
 
-    $ pyenv global 2.7.12 3.5.2
-    $ pyenv rehash
+    pyenv global 2.7.12 3.5.2
+    pyenv rehash
 
 The leading version takes priority. All installed Python versions can be
 located in `~/.pyenv/versions`. Alternatively, you can run:

--- a/Python/ipython.md
+++ b/Python/ipython.md
@@ -1,14 +1,14 @@
 # IPython
 
-[IPython](http://ipython.org/) is an improved Python shell than the one you get from running `$ python` in the command-line. It has many cool functions (running Unix commands from the Python shell, easy copy & paste, creating Matplotlib charts in-line etc.). You can find all functions in the [documentation](http://ipython.readthedocs.io/en/stable/).
+[IPython](http://ipython.org/) is an improved Python shell than the one you get from running `python` in the command-line. It has many cool functions (running Unix commands from the Python shell, easy copy & paste, creating Matplotlib charts in-line etc.). You can find all functions in the [documentation](http://ipython.readthedocs.io/en/stable/).
 IPython is a kernel for Jupyter Notebook. If you are confused IPython with Jupyter, refer to the [Jupyter documentation](http://jupyter.readthedocs.io/en/latest/ipython/content-ipython.html)
 
 ## Installation
 
-    $ pip install ipython
+    pip install ipython
 
 If you want a more fine grained command you can try the following:
 
-For zsh -> `$ pip install 'ipython[zmq,qtconsole,notebook,test]'`
+For zsh -> `pip install 'ipython[zmq,qtconsole,notebook,test]'`
 
-For bash -> `$ pip install ipython[zmq,qtconsole,notebook,test]`
+For bash -> `pip install ipython[zmq,qtconsole,notebook,test]`

--- a/Python/numpy.md
+++ b/Python/numpy.md
@@ -4,19 +4,19 @@ The [Numpy](http://numpy.scipy.org/), [Scipy](https://www.scipy.org/scipylib/ind
 
 First, grab the special formulae (which are not part of Homebrew core):
 
-    $ brew tap samueljohn/python
-    $ brew tap brewsci/bio
+    brew tap samueljohn/python
+    brew tap brewsci/bio
 
 Then, install the `gfortran` dependency which we will need to build the libraries along with gcc:
 
-    $ brew install gcc
+    brew install gcc
 
 Then, install `nose`, `pyparsing` and `python-dateutil` dependency which we will need to build the libraries:
 
-    $ pip install nose pyparsing python-dateutil pep8
+    pip install nose pyparsing python-dateutil pep8
 
 Finally, you can install Numpy and Scipy with:
 
-    $ brew install numpy scipy matplotlib
+    brew install numpy scipy matplotlib
 
 (It may take a few minutes to build)

--- a/Python/pip.md
+++ b/Python/pip.md
@@ -4,12 +4,12 @@ macOS comes with Python so there's a chance `pip` is already installed on your m
 
 ## Installation
 
-    $ curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-    $ sudo python get-pip.py
+    curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+    sudo python get-pip.py
 
 To verify `pip` is installed properly run
 
-    $ pip --version
+    pip --version
 
 If it returns a version `pip` was successfully installed.
 
@@ -19,16 +19,16 @@ Here are a few `pip` commands to get you started.
 
 Install a Python package
 
-    $ pip install <package>
+    pip install <package>
 
 Upgrade a package
 
-    $ pip install --upgrade <package>
+    pip install --upgrade <package>
 
 See what's installed
 
-    $ pip freeze
+    pip freeze
 
 Uninstall a package
 
-    $ pip uninstall <package>
+    pip uninstall <package>

--- a/Python/virtualenv.md
+++ b/Python/virtualenv.md
@@ -12,38 +12,38 @@ use `virtualenv` when dealing with Python applications.
 
 To install `virtualenv` run:
 
-    $ pip install virtualenv
+    pip install virtualenv
 
 ## Usage
 
 If you have a project in a directory called `my-project` you can set up
 `virtualenv` for that project by running:
 
-    $ cd my-project/
-    $ virtualenv venv
+    cd my-project/
+    virtualenv venv
 
 If you want your `virtualenv` to also inherit globally installed packages run:
 
-    $ virtualenv venv --system-site-packages
+    virtualenv venv --system-site-packages
 
 These commands create a `venv/` directory in your project where all
 dependencies are installed. You need to **activate** it first though (in every
 terminal instance where you are working on your project):
 
-    $ source venv/bin/activate
+    source venv/bin/activate
 
 You should see a `(venv)` appear at the beginning of your terminal prompt
 indicating that you are working inside the `virtualenv`. Now when you install
 something like this:
 
-    $ pip install <package>
+    pip install <package>
 
 It will get installed in the `venv/` folder, and not conflict with other
 projects.
 
 To leave the virtual environment run:
 
-    $ deactivate
+    deactivate
 
 **Important**: Remember to add `venv` to your project's `.gitignore` file so
 you don't include all of that in your source code.
@@ -60,7 +60,7 @@ dependency conflicts.
 
 To install `virtualenvwrapper` run:
 
-    $ pip install virtualenvwrapper
+    pip install virtualenvwrapper
 
 Depending on your setup you might need to install it using `sudo`. Read the
 [installation

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -4,9 +4,9 @@ macOS comes with Ruby installed, but as we don't want to be messing with operati
 
 ## Installation
 
-    $ brew install rbenv ruby-build rbenv-default-gems rbenv-gemset
-    $ echo 'eval "$(rbenv init -)"' >> ~/Projects/config/env.sh
-    $ source ~/.zshrc # Apply changes
+    brew install rbenv ruby-build rbenv-default-gems rbenv-gemset
+    echo 'eval "$(rbenv init -)"' >> ~/Projects/config/env.sh
+    source ~/.zshrc # Apply changes
 
 The packages we just installed allow us to install different versions of Ruby and specify which version to use on a per project basis and globally. This is very useful to keep a consistent development environment if you need to work in a particular Ruby version.
 
@@ -14,19 +14,19 @@ The packages we just installed allow us to install different versions of Ruby an
 
 We can install version 2.1.1 and use it as our global version by running:
 
-    $ rbenv install 2.1.1
-    $ rbenv global 2.1.1
+    rbenv install 2.1.1
+    rbenv global 2.1.1
 
 ## Managing gems in application
 
 Bundler provides a consistent environment for Ruby projects by tracking and installing the exact gems and versions that are needed.
 
-    $ gem install bundler
-    $ echo 'bundler' >> "$(brew --prefix rbenv)/default-gems"
+    gem install bundler
+    echo 'bundler' >> "$(brew --prefix rbenv)/default-gems"
 
 When starting a Ruby project, you can have sandboxed collections of gems. This lets you have multiple collections of gems installed in different sandboxes, and specify (on a per-application basis) which sets of gems should be used. To have gems install into a sub-folder in your project directory for easy later removal / editing / testing, you can use a project gemset.
 
-    $ echo '.gems' > <my_project_path>/.rbenv-gemsets
+    echo '.gems' > <my_project_path>/.rbenv-gemsets
 
 Your gems will then get installed in `project/.gems`.
 
@@ -34,4 +34,4 @@ Your gems will then get installed in `project/.gems`.
 
 If you use Google for finding your Gem documentation then you might want to consider saving a bit of time when installing gems by not including the documentation.
 
-    $ echo 'gem: --no-document' >> ~/.gemrc
+    echo 'gem: --no-document' >> ~/.gemrc

--- a/Ruby/RubyGems.md
+++ b/Ruby/RubyGems.md
@@ -2,40 +2,40 @@
 
 [RubyGems](http://rubygems.org/), the Ruby package manager, should be installed on your machine if you previously have installed Ruby. Verify this by running:
 
-    $ which gem
+    which gem
 
 ## Update RubyGems
 
 To update to its latest version with:
 
-    $ gem update --system
+    gem update --system
 
 ## Install gems
 
 To install a _gem_ (Ruby package), run:
 
-    $ gem install <gemname>
+    gem install <gemname>
 
 To install without generating the documentation for each gem (faster):
 
-    $ gem install <gemname> --no-document
+    gem install <gemname> --no-document
 
 ## List installed gems
 
-    $ gem list
+    gem list
 
 To check if any installed gems are outdated:
 
-    $ gem outdated
+    gem outdated
 
 ## Update installed gems
 
 To update all gems or a particular gem:
 
-    $ gem update [<gemname>]
+    gem update [<gemname>]
 
 ## Remove old gem versions
 
 RubyGems keeps old versions of gems, so feel free to do some cleaning after updating:
 
-    $ gem cleanup
+    gem cleanup

--- a/Rust/README.md
+++ b/Rust/README.md
@@ -9,19 +9,19 @@ allow you to switch between versions of Rust without having to download
 anything additional.
 
 ```sh
-$ brew install rustup
+brew install rustup
 ```
 
 Use rustup to install the Rust compiler (rustc) and the Rust package manager (cargo).
 
 ```sh
-$ rustup-init
+rustup-init
 ```
 
 To verify you can run:
 
 ```sh
-$ rustc --version
+rustc --version
 ```
 
 [The official documentation on how to install Rust](https://www.rust-lang.org/en-US/install.html).

--- a/Scala/README.md
+++ b/Scala/README.md
@@ -2,13 +2,13 @@
 
 Make sure you have Java installed, the instructions are provided [here](/mac-setup/Java/README.html).
 
-    $ brew update
-    $ brew install scala sbt
+    brew update
+    brew install scala sbt
 
 (This step is optional) Update the `/usr/local/etc/sbtopts` by running the command below.
 
-    $ echo '-J-XX:+CMSClassUnloadingEnabled' >> /usr/local/etc/sbtopts
-    $ echo '-J-Xmx2G' >> /usr/local/etc/sbtopts
+    echo '-J-XX:+CMSClassUnloadingEnabled' >> /usr/local/etc/sbtopts
+    echo '-J-Xmx2G' >> /usr/local/etc/sbtopts
 
 ## Scala Plugin for Eclipse
 

--- a/SublimeText/README.md
+++ b/SublimeText/README.md
@@ -10,9 +10,9 @@
 
 Let's create a shortcut so we can launch Sublime Text from the command-line
 
-    $ ln -s /Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl /usr/local/bin/subl
+    ln -s /Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl /usr/local/bin/subl
 
-Now you can open a file with `$ subl myfile.py` or start a new project in the current directory with `$ subl .`.
+Now you can open a file with `subl myfile.py` or start a new project in the current directory with `subl .`.
 
 ## Pricing
 

--- a/SystemPreferences/README.md
+++ b/SystemPreferences/README.md
@@ -34,8 +34,8 @@ suggestions. Always choose the setting that makes the most sense to you.**
     - Remove _workspace auto-switching_ by running the following command:
 
 ```shell
-$ defaults write com.apple.dock workspaces-auto-swoosh -bool NO
-$ killall Dock # Restart the Dock process
+defaults write com.apple.dock workspaces-auto-swoosh -bool NO
+killall Dock # Restart the Dock process
 ```
 
 ## Finder
@@ -80,18 +80,18 @@ Instructions [here](https://sourabhbajaj.com/mac-setup/Homebrew/README.html).
 
 ### 2) Update Homebrew formulae
 
-    $ brew update
+    brew update
 
 ### 3) Install osxfuse
 
 If you are on macOS El Capitan (10.11), install the (3.x.x) from [the
 repo](https://github.com/osxfuse/osxfuse/releases).
 
-    $ brew cask install osxfuse
+    brew cask install osxfuse
 
 ### 4) Install ntfs-3g
 
-    $ brew install ntfs-3g
+    brew install ntfs-3g
 
 ### 5) If you are on macOS El Capitan (10.11), temporarily disable System Integrity Protection
 
@@ -99,7 +99,7 @@ repo](https://github.com/osxfuse/osxfuse/releases).
  - Open the terminal and type:
 
 ```shell
-$ csrutil disable
+csrutil disable
 ```
 
  - **Reboot** normally
@@ -107,8 +107,8 @@ $ csrutil disable
 ### 6) Create a symlink for mount_ntfs
 
 ```shell
-$ sudo mv /sbin/mount_ntfs /sbin/mount_ntfs.original
-$ sudo ln -s /usr/local/sbin/mount_ntfs /sbin/mount_ntfs
+sudo mv /sbin/mount_ntfs /sbin/mount_ntfs.original
+sudo ln -s /usr/local/sbin/mount_ntfs /sbin/mount_ntfs
 ```
 
 ### 7) If you are on macOS El Capitan (10.11), re-enable System Integrity Protection
@@ -117,7 +117,7 @@ $ sudo ln -s /usr/local/sbin/mount_ntfs /sbin/mount_ntfs
  - Open the terminal and type:
 
 ```shell
-$ csrutil enable
+csrutil enable
 ```
 
  - **Reboot** normally

--- a/Vagrant/README.md
+++ b/Vagrant/README.md
@@ -12,38 +12,38 @@ Vagrant uses [Virtualbox](https://www.virtualbox.org/) to manage the virtual dep
 Notice that macOS High Sierra 10.13 introduces a new feature that requires user approval before loading new third-party kernel extensions.
 In case of failure follow the instructions [here](https://developer.apple.com/library/archive/technotes/tn2459/_index.html).
 
-    $ brew cask install virtualbox
+    brew cask install virtualbox
 
 Now install Vagrant either [from the website](http://www.vagrantup.com/downloads.html) or use Homebrew for installing it.
 
-    $ brew cask install vagrant
+    brew cask install vagrant
 
 [Vagrant-Manager](http://vagrantmanager.com/) helps you manage all your virtual machines in one place directly from the menu bar.
 
-    $ brew cask install vagrant-manager
+    brew cask install vagrant-manager
 
 ## Usage
 
 Add the Vagrant box you want to use. We'll use Ubuntu 12.04 for the following example.
 
-    $ vagrant box add precise64 https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box
+    vagrant box add precise64 https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box
 
 You can find more boxes at [Vagrant Cloud](https://app.vagrantup.com/boxes/search).
 
 Now create a test directory and `cd` into the test directory. Then we'll initialize the vagrant machine.
 
-    $ vagrant init precise64
+    vagrant init precise64
 
 Now lets start the machine using the following command.
 
-    $ vagrant up
+    vagrant up
 
 You can ssh into the machine now.
 
-    $ vagrant ssh
+    vagrant ssh
 
 Halt the vagrant machine now.
 
-    $ vagrant halt
+    vagrant halt
 
 Other useful commands are `suspend` and `destroy`.

--- a/Xcode/README.md
+++ b/Xcode/README.md
@@ -6,7 +6,7 @@ Download and install it from the App Store or from [Apple's website](https://dev
 
 For installing Xcode command line tools run:
 
-    $ xcode-select --install
+    xcode-select --install
 
 It'll prompt you to install the command line tools. Follow the instructions and you'll have Xcode and Xcode command line tools both installed.
 

--- a/iTerm/ack.md
+++ b/iTerm/ack.md
@@ -8,7 +8,7 @@
 To install the latest version, use homebrew.
 
 ```bash
-$ brew install ack
+brew install ack
 ```
 
 ## Why use `ack` over `grep`
@@ -21,20 +21,20 @@ $ brew install ack
 ## Usage
 
 ```bash
-$ ack [OPTION]... PATTERN [FILES OR DIRECTORIES]
+ack [OPTION]... PATTERN [FILES OR DIRECTORIES]
 ```
 
 Let's say you want to find all JavaScript files that are using the module
 `pancakes` in your project, with `ack` it's as easy as
 
 ```sh
-$ ack --js pancakes
+ack --js pancakes
 ```
 
 Or you may want to find all files that _does not_ contain the word _brew_
 
 ```bash
-$ ack -L brew
+ack -L brew
 ```
 
 ## Customization
@@ -60,7 +60,7 @@ You can also tell ack to always sort and use colors in the result.
 To see what configuration `ack` uses you can use the `dump` flag.
 
 ```bash
-$ ack --dump
+ack --dump
 ```
 
 ## Alternatives to `ack`

--- a/iTerm/autojump.md
+++ b/iTerm/autojump.md
@@ -7,7 +7,7 @@
 To install the latest version, use homebrew:
 
 ```bash
-$ brew install autojump
+brew install autojump
 ```
 
 ## Usage

--- a/iTerm/fzf.md
+++ b/iTerm/fzf.md
@@ -9,11 +9,11 @@ tools it becomes super powerful.
 Use [homebrew](http://sourabhbajaj.com/mac-setup/Homebrew/README.html) to
 install `fzf`:
 
-    $ brew install fzf
+    brew install fzf
 
 If you want to use shell extensions (better shell integration):
 
-    $ /usr/local/opt/fzf/install
+    /usr/local/opt/fzf/install
 
 which gives you:
 

--- a/iTerm/tree.md
+++ b/iTerm/tree.md
@@ -7,7 +7,7 @@
 To install the latest version, use homebrew:
 
 ```bash
-$ brew install tree
+brew install tree
 ```
 
 ## Usage
@@ -42,7 +42,7 @@ Running `tree` will produce output like this:
 To limit the recursion you can pass an `-L` flag and specify the maximum depth `tree` will use when searching.
 
 ```bash
-$ tree -L 1
+tree -L 1
 ```
 
 will output:

--- a/iTerm/zsh.md
+++ b/iTerm/zsh.md
@@ -12,7 +12,7 @@ configuration file too much. This file is found in the bottom of this page.
 Install `zsh` using Homebrew:
 
 ```sh
-$ brew install zsh
+brew install zsh
 ```
 
 Now you should install a framework, we recommend to use [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh)
@@ -31,14 +31,14 @@ with a bunch of features out of the box and improves your terminal experience.
 Install Oh My Zsh:
 
 ```sh
-$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 ```
 
 The installation script should set `zsh` to your default shell, but if it
 doesn't you can do it manually:
 
 ```sh
-$ chsh -s $(which zsh)
+chsh -s $(which zsh)
 ```
 
 ### Configuration
@@ -52,7 +52,7 @@ To apply the changes you make you need to either **start new shell instance**
 or run:
 
 ```sh
-$ source ~/.zshrc
+source ~/.zshrc
 ```
 
 #### Plugins
@@ -89,14 +89,14 @@ defaults, aliases, functions, auto completion, and prompt themes.
 Install Prezto:
 
 ```sh
-$ git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
+git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
 ```
 
 Next create your `~/.zshrc` by running:
 
 ```sh
-$ setopt EXTENDED_GLOB
-$ for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
+setopt EXTENDED_GLOB
+for rcfile in "${ZDOTDIR:-$HOME}"/.zprezto/runcoms/^README.md(.N); do
     ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
   done
 ```
@@ -132,7 +132,7 @@ And don't forget to apply your changes by **starting a new shell instance**.
 To list all available themes run:
 
 ```sh
-$ prompt -l
+prompt -l
 ```
 
 Then open up your config file (`~/.zpreztorc`) and change to the theme you want:


### PR DESCRIPTION
Having the terminal prompt makes it harder to copy-paste the command.
Only use them for examples where the output is shown, so it's obvious
that is the command and what is the result.

WDYT? @sb2nov @hugovk @Kyslik 