### PR TITLE
Update Java installation instructions for 2020

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -11,36 +11,23 @@ They differ only in their packaging and licensing.
 
 OpenJDK is free for use in all situations.
 Oracle JDK requires a paid-for commercial license when used in a production setting.
-(And "production" may have a broader meaning than you expect.)
 
-Most personal users will probably want to use OpenJDK, since it's easier to acquire and install.
-
-If you're setting up a Mac in a business, academic, or institutional setting, your organization's policy
-may require you to use one or the other of OpenJDK or Oracle JDK.
-Check with your IT department to see which one you should use.
+Most personal users will probably want to use OpenJDK, since it's easier to acquire and install
+and that's what we'll be covering here.
 
 ## Installation
 
-First you should check if Java is already installed. Run this in a terminal session:
+First you should check if Java is already installed
 
     java -version
 
-If you see an output like below then Java is already installed on your machine and you are good to go:
+If you see a non-empty output like below then Java is already installed on your machine and you are good to go
 
     openjdk version "13.0.2" 2020-01-14
     OpenJDK Runtime Environment AdoptOpenJDK (build 13.0.2+8)
     OpenJDK 64-Bit Server VM AdoptOpenJDK (build 13.0.2+8, mixed mode, sharing)
 
-You might also see something like this:
-
-    java version "1.8.0_45"
-    Java(TM) SE Runtime Environment (build 1.8.0_45-b14)
-    Java HotSpot(TM) 64-Bit Server VM (build 25.45-b02, mixed mode)
-
-Which means you have the old Oracle version of Java installed. That is fine, too.
-(Unless you're in a corporate environment; see the note at the end of this page.)
-
-If you don't see the output like above then you need to install Java on your system.
+If you don't see the output like above then you need to install Java on your system
 
 ### Installing OpenJDK
 
@@ -62,9 +49,3 @@ Open a web browser and go to <https://adoptopenjdk.net/>. Select "OpenJDK 11 (LT
 Click the big "Latest release" button and run the installer file that gets downloaded.
 
 Once you've done that, check if Java is correctly installed by opening a new Terminal session and running the `java -version` command again.
-
-### Installing Oracle JDK
-
-Go to <https://www.oracle.com/java/technologies/javase-jdk11-downloads.html>.
-Review the licensing terms, and then download the "macOS Installer" download.
-Run it and select all the defaults.

--- a/Java/README.md
+++ b/Java/README.md
@@ -1,46 +1,70 @@
 # Java
 
+Using Java requires you to install a JDK ("Java Development Kit") or JRE ("Java Runtime Environment").
+We'll use a JDK since it can do everything a JRE can, plus more.
+
+## Choosing a JDK
+
+As of 2019, there are two major JDKs: OpenJDK (also known as AdoptOpenJDK) and the Oracle JDK.
+OpenJDK and Oracle JDK provide the same functionality, and are even built from the same code base.
+They differ only in their packaging and licensing.
+
+OpenJDK is free for use in all situations.
+Oracle JDK requires a paid-for commercial license when used in a production setting.
+(And "production" may have a broader meaning than you expect.)
+
+Most personal users will probably want to use OpenJDK, since it's easier to acquire and install.
+
+If you're setting up a Mac in a business, academic, or institutional setting, your organization's policy
+may require you to use one or the other of OpenJDK or Oracle JDK.
+Check with your IT department to see which one you should use.
+
 ## Installation
 
-First you should check if Java is already installed
+First you should check if Java is already installed. Run this in a terminal session:
 
     java -version
 
-If you see an output like below then Java is already installed on your machine so skip to _Add Java to PATH_.
+If you see an output like below then Java is already installed on your machine and you are good to go:
+
+    openjdk version "13.0.2" 2020-01-14
+    OpenJDK Runtime Environment AdoptOpenJDK (build 13.0.2+8)
+    OpenJDK 64-Bit Server VM AdoptOpenJDK (build 13.0.2+8, mixed mode, sharing)
+
+You might also see something like this:
 
     java version "1.8.0_45"
     Java(TM) SE Runtime Environment (build 1.8.0_45-b14)
     Java HotSpot(TM) 64-Bit Server VM (build 25.45-b02, mixed mode)
 
+Which means you have the old Oracle version of Java installed. That is fine, too.
+(Unless you're in a corporate environment; see the note at the end of this page.)
+
 If you don't see the output like above then you need to install Java on your system.
 
-### Using Homebrew
+### Installing OpenJDK
 
-    brew update
-    brew tap AdoptOpenJDK/openjdk
+#### Installing OpenJDK using Homebrew
 
-You can list the available JDK versions via:
+    brew install openjdk
+
+If you're curious, you can list all the available JDK versions via:
 
     brew search jdk
 
-The current LTS release of Java is JDK 11, which you can install via:
+There will be a lot of options here! If you are not a serious Java developer, don't worry about them, and just use the default `openjdk`.
 
-    brew cask install adoptopenjdk11
+Once you've done that, check if Java is correctly installed by running the `java -version` command again.
 
-If you wish to install Java 8, you can do so with:
+#### Downloading and installing OpenJDK manually
 
-    brew cask install adoptopenjdk8
+Open a web browser and go to <https://adoptopenjdk.net/>. Select "OpenJDK 11 (LTS)" and "HotSpot".
+Click the big "Latest release" button and run the installer file that gets downloaded.
 
-Check if Java is correctly installed by running the `java -version` command again.
+Once you've done that, check if Java is correctly installed by opening a new Terminal session and running the `java -version` command again.
 
-### Using the Oracle installer
+### Installing Oracle JDK
 
-Please [download the macOS version](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) as per the instructions on the [Oracle website](https://docs.oracle.com/en/java/javase/11/install/installation-jdk-macos.html#GUID-F575EB4A-70D3-4AB4-A20E-DBE95171AB5F). Do note that this method requires you to login/create a new account with Oracle.
-
-#### Add Java to PATH
-
-Add `JAVA_HOME` to your environment variables by adding the line below to your `env.sh` (see [iTerm2](/mac-setup/iTerm/README.html) section if you don't have a `env.sh` file).
-
-    export JAVA_HOME=`/usr/libexec/java_home -v 11`
-
-You should have Java working now. Two popular IDE alternatives for writing Java are [IntelliJ](https://www.jetbrains.com/idea/download/) or [Eclipse](https://www.eclipse.org/downloads/).
+Go to <https://www.oracle.com/java/technologies/javase-jdk11-downloads.html>.
+Review the licensing terms, and then download the "macOS Installer" download.
+Run it and select all the defaults.


### PR DESCRIPTION
Changes all the Java installation instructions to <strike>just tell everyone to use OpenJDK</strike> reflect how JDKs work in 2019 and later.

And the installation process is simpler now!