### PR TITLE
Remove references to linkapps in emacs mac installation document

### DIFF
--- a/Emacs/README.md
+++ b/Emacs/README.md
@@ -49,6 +49,7 @@ brew tap railwaycat/emacsmacport
 ### [Emacs plus](https://github.com/d12frosted/homebrew-emacs-plus#emacs-plus)
 
 Start off by tapping the official emacs-plus cask.
+
 ```shell
 brew tap d12frosted/emacs-plus
 ```
@@ -56,15 +57,20 @@ brew tap d12frosted/emacs-plus
 Emacs Plus contains separate formulas for different Emacs versions:
 
 * emacs-plus - installs Emacs 26, current release version.
-```
+
+```shell
 brew install emacs-plus [options]
 ```
+
 * emacs-plus@27 - installs Emacs 27, next release version.
-```
+
+```shell
 brew install emacs-plus@27 [options]
 ```
+
 * emacs-plus@28 - installs Emacs 28, development version.
-```
+
+```shell
 brew install emacs-plus@28 [options]
 ```
 

--- a/Emacs/README.md
+++ b/Emacs/README.md
@@ -26,11 +26,10 @@ brew tap railwaycat/emacsmacport
 
   There are three available versions, `emacs-mac`, `emacs-mac-official-icon`, `emacs-mac-spacemacs-icon`.
 
-* Method 2: Build from source with Homebrew.
+* Method 2: Install using `brew`.
 
   ```shell
   brew install emacs-mac [options]
-  brew linkapps emacs-mac
   ```
 
 <details>
@@ -49,10 +48,24 @@ brew tap railwaycat/emacsmacport
 
 ### [Emacs plus](https://github.com/d12frosted/homebrew-emacs-plus#emacs-plus)
 
+Start off by tapping the official emacs-plus cask.
 ```shell
 brew tap d12frosted/emacs-plus
+```
+
+Emacs Plus contains separate formulas for different Emacs versions:
+
+* emacs-plus - installs Emacs 26, current release version.
+```
 brew install emacs-plus [options]
-brew linkapps emacs-plus
+```
+* emacs-plus@27 - installs Emacs 27, next release version.
+```
+brew install emacs-plus@27 [options]
+```
+* emacs-plus@28 - installs Emacs 28, development version.
+```
+brew install emacs-plus@28 [options]
 ```
 
 <details>


### PR DESCRIPTION
Relevant issue: https://github.com/sb2nov/mac-setup/issues/249#issue-410111739

Change Made:
`linkapps` is deprecated. Updated installations do not require this command and there are new installation methods to do the same