### PR TITLE
Docker and emac-mac documentation update

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -18,7 +18,9 @@ You'll need `homebrew-cask` to install Docker Toolbox, if you don't have it refe
 
 ### Installation
 
-These are the steps to install docker using brew
+There are two ways to install Docker
+
+Option 1: These are the steps to install docker using brew
 
 * Install the docker and docker machine from brew
 
@@ -64,3 +66,13 @@ docker run hello-world
 ```
 
 You can find more about Docker in the [documentation](https://docs.docker.com/).
+
+Option 2: Install using the Docker App
+
+* Navigate to 
+
+```shell script
+https://hub.docker.com/editions/community/docker-ce-desktop-mac/
+```
+
+This installation should provide you all the necessary GUI tools

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -37,7 +37,7 @@ brew cask install virtualbox
 ```shell script
 The install failed (The installer encountered an error that caused the installation to fail.
 Contact the software manufacturer for assistance.)
-``` 
+```
 
 >Use the following When you do fail, turn on System Preference and see if ‘System software from developer “Oracle America, inc” was blocked from loading.’ If you see that message, click Allow button and try to install again.
 
@@ -62,6 +62,5 @@ Finally, to verify all the installations:
 ```shell script
 docker run hello-world
 ```
-
 
 You can find more about Docker in the [documentation](https://docs.docker.com/).

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -69,7 +69,7 @@ You can find more about Docker in the [documentation](https://docs.docker.com/).
 
 Option 2: Install using the Docker App
 
-* Navigate to 
+* Navigate to the following link
 
 ```shell script
 https://hub.docker.com/editions/community/docker-ce-desktop-mac/

--- a/Emacs/README.md
+++ b/Emacs/README.md
@@ -49,6 +49,7 @@ brew tap railwaycat/emacsmacport
 ### [Emacs plus](https://github.com/d12frosted/homebrew-emacs-plus#emacs-plus)
 
 Start off by tapping the official emacs-plus cask.
+
 ```shell
 brew tap d12frosted/emacs-plus
 ```
@@ -56,15 +57,20 @@ brew tap d12frosted/emacs-plus
 Emacs Plus contains separate formulas for different Emacs versions:
 
 * emacs-plus - installs Emacs 26, current release version.
-```
+
+```shell
 brew install emacs-plus [options]
 ```
+
 * emacs-plus@27 - installs Emacs 27, next release version.
-```
+
+```shell
 brew install emacs-plus@27 [options]
 ```
+
 * emacs-plus@28 - installs Emacs 28, development version.
-```
+
+```shell
 brew install emacs-plus@28 [options]
 ```
 

--- a/Emacs/README.md
+++ b/Emacs/README.md
@@ -26,11 +26,10 @@ brew tap railwaycat/emacsmacport
 
   There are three available versions, `emacs-mac`, `emacs-mac-official-icon`, `emacs-mac-spacemacs-icon`.
 
-* Method 2: Build from source with Homebrew.
+* Method 2: Install using `brew`.
 
   ```shell
   brew install emacs-mac [options]
-  brew linkapps emacs-mac
   ```
 
 <details>
@@ -49,10 +48,24 @@ brew tap railwaycat/emacsmacport
 
 ### [Emacs plus](https://github.com/d12frosted/homebrew-emacs-plus#emacs-plus)
 
+Start off by tapping the official emacs-plus cask.
 ```shell
 brew tap d12frosted/emacs-plus
+```
+
+Emacs Plus contains separate formulas for different Emacs versions:
+
+* emacs-plus - installs Emacs 26, current release version.
+```
 brew install emacs-plus [options]
-brew linkapps emacs-plus
+```
+* emacs-plus@27 - installs Emacs 27, next release version.
+```
+brew install emacs-plus@27 [options]
+```
+* emacs-plus@28 - installs Emacs 28, development version.
+```
+brew install emacs-plus@28 [options]
 ```
 
 <details>


### PR DESCRIPTION
updating the documentation for Docker and Emac-mac documents.

Relevant issues:

https://github.com/sb2nov/mac-setup/issues/232#issue-389195473 - Docker installation having issues in Mac through brew

and 

https://github.com/sb2nov/mac-setup/issues/249#issue-410111739 - homebrew linkapps deprecated