### PR TITLE
Remove Python dependency for deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "devDependencies": {
     "gitbook": "3.2.3",
     "gitbook-cli": "2.3.2",
-    "markdownlint-cli": "0.23.2"
+    "markdownlint-cli": "0.23.2",
+    "node-fetch": "2.6.0"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate_contributors.js
+++ b/scripts/generate_contributors.js
@@ -15,7 +15,7 @@ const FILE_NAME = "Contributors.md";
 const BASE_URL = "https://api.github.com/repos/sb2nov/mac-setup/contributors?page=";
 const HEADER = `# Contributors
 
-Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [GitHub Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
+Thank you everyone that have contributed to creating this awesome guide!
 
 `;
 

--- a/scripts/generate_contributors.js
+++ b/scripts/generate_contributors.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/*
+ * This script fetches contributors and writes their usernames and url
+ * to the Contributors.md file.
+ */
+
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+// Each call to the endpoint returns 30 contributors. In total we'll fetch
+// PAGE_COUNT * 30 contributors.
+const PAGE_COUNT = 4;
+const FILE_NAME = "Contributors.md";
+const BASE_URL = "https://api.github.com/repos/sb2nov/mac-setup/contributors?page=";
+const HEADER = `# Contributors
+
+Thank you everyone that have contributed to creating this awesome guide. Here are the names of a few; for the full list please visit the [GitHub Contributor page](https://github.com/sb2nov/mac-setup/graphs/contributors).
+
+`;
+
+const validateWorkingDirectory = () => {
+  const cwd = process.cwd();
+
+  if (!cwd.endsWith("/mac-setup")) {
+    throw new Error("Script must be run from repo root");
+  }
+};
+
+const fetchContributor = async url => {
+  try {
+    const response = await fetch(url);
+    const json = await response.json();
+    return json;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+const fetchContributors = () => {
+  return [...Array(PAGE_COUNT).keys()]
+    .map(i => i + 1)
+    .map(i => `${BASE_URL}${i}`)
+    .map(fetchContributor);
+};
+
+// Validate username to not contain anything naughty
+const validateUsername = contributor => {
+  const username = contributor.login;
+
+  return !username.includes("<script");
+};
+
+const parseContributors = contributors => {
+  return contributors
+    .flatMap(c => c)
+    .filter(validateUsername)
+    .map(c => `- [${c.login}](${c.html_url})`)
+    .join('\n');
+};
+
+const writeToFile = content =>
+  fs.writeFile(FILE_NAME, content, err => {
+    if (err) throw new Error(err);
+  });
+
+const run = promises =>
+  Promise.all(promises)
+    .then(contributors => {
+      const contributorsMarkdown = parseContributors(contributors);
+      const fileContent = HEADER + contributorsMarkdown + '\n';
+
+      writeToFile(fileContent);
+    });
+
+validateWorkingDirectory();
+
+const promises = fetchContributors();
+run(promises);

--- a/scripts/publish_gitbook.sh
+++ b/scripts/publish_gitbook.sh
@@ -18,7 +18,7 @@ for cmd in ${commands[@]}; do is_available "$cmd"; done
 echo "✅ All required packages are available, will continue"
 
 echo "👥 Updating list of contributors.."
-python ./scripts/contributors.py
+node ./scripts/generate_contributors.js
 git commit -a -m "Update list of contributors"
 git push origin master
 echo "👥 Completed updating list of contributors"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,6 +3485,11 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-gyp@~3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.3.1.tgz#80f7b6d7c2f9c0495ba42c518a670c99bdf6e4a0"


### PR DESCRIPTION
The python script required a virtualenv to have all of its
dependencies, or have them installed globally on your machine. Since
we're already installing dependencies using npm/yarn I figured we can
just add one more dependency and not have to worry about Python.

I've tested the new script and it outputs the exact same content as the
python script.

Let me know what you think!