### PR TITLE
update health-check branch to point to the `main` branch instead of ` master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ services:
   - docker
 
 script:
-  - git clone --depth 1 https://github.com/sb2nov/mac-setup mac-setup-master
-  - cd mac-setup-master
+  - git clone --depth 1 https://github.com/sb2nov/mac-setup mac-setup-main
+  - cd mac-setup-main
   - docker run -ti --rm -v $PWD:/mnt:ro simeg/urlsup `find . -name "*.md"` --threads 10 --allow 429 --white-list http://localhost

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 ====================
 branch | status
 | ---- | ---- |
-| `master` | [![master branch](https://travis-ci.org/sb2nov/mac-setup.svg?branch=master)](https://travis-ci.org/sb2nov/mac-setup) |
+| `main` | [![main branch](https://travis-ci.org/sb2nov/mac-setup.svg?branch=main)](https://travis-ci.org/sb2nov/mac-setup) |
 | `health-check` | [![health-check branch](https://img.shields.io/travis/sb2nov/mac-setup/health-check.svg?label=links)](https://travis-ci.org/sb2nov/mac-setup) |
 
 This branch is only for checking the health of links in the guide.
 
 It runs daily via cron on Travis CI.
 
-Please visit the [master branch](https://github.com/sb2nov/mac-setup/).
+Please visit the [main branch](https://github.com/sb2nov/mac-setup/).


### PR DESCRIPTION
Updating the health-check branch to point to the `main` branch instead of the `master` branch.

Reference issue:  https://github.com/sb2nov/mac-setup/issues/298