### PR TITLE
Add Live Server and vscode-icons to VSCode

### DIFF
--- a/VisualStudioCode/README.md
+++ b/VisualStudioCode/README.md
@@ -65,4 +65,4 @@ After that, you can launch VS Code from your terminal:
 
 ### VS Code Icons
 
-* [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons) - Adds unique icons to distinguish different file extensions (easier to glance through your directories).
+* [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons) - Adds unique icons to distinguish different file extensions (easier to glance through your directories)

--- a/VisualStudioCode/README.md
+++ b/VisualStudioCode/README.md
@@ -61,3 +61,6 @@ After that, you can launch VS Code from your terminal:
 
 ### Live Server
 * [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) - Launches a local development server with live reloading for both static and dynampic. Quick and hassle-free.
+
+### VS Code Icons
+* [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons) - Adds unique icons to distinguish different file extensions (easier to glance through your directories).

--- a/VisualStudioCode/README.md
+++ b/VisualStudioCode/README.md
@@ -58,3 +58,6 @@ After that, you can launch VS Code from your terminal:
 ### JSON
 
 * [Paste JSON as Code](https://marketplace.visualstudio.com/items?itemName=quicktype.quicktype) - Infers types from sample JSON data, then outputs strongly typed models and serializers for working with that data in your desired programming language
+
+### Live Server
+* [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) - Launches a local development server with live reloading for both static and dynampic. Quick and hassle-free.

--- a/VisualStudioCode/README.md
+++ b/VisualStudioCode/README.md
@@ -60,7 +60,9 @@ After that, you can launch VS Code from your terminal:
 * [Paste JSON as Code](https://marketplace.visualstudio.com/items?itemName=quicktype.quicktype) - Infers types from sample JSON data, then outputs strongly typed models and serializers for working with that data in your desired programming language
 
 ### Live Server
+
 * [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) - Launches a local development server with live reloading for both static and dynampic. Quick and hassle-free.
 
 ### VS Code Icons
+
 * [vscode-icons](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons) - Adds unique icons to distinguish different file extensions (easier to glance through your directories).

--- a/VisualStudioCode/README.md
+++ b/VisualStudioCode/README.md
@@ -61,7 +61,7 @@ After that, you can launch VS Code from your terminal:
 
 ### Live Server
 
-* [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) - Launches a local development server with live reloading for both static and dynampic. Quick and hassle-free.
+* [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) - Launches a local development server with live reloading for both static and dynamic
 
 ### VS Code Icons
 


### PR DESCRIPTION
Added Live Server and vscode-icons to Visual Studio Code's useful extensions subsection.