### PR TITLE
Add homebrew option to nvm installation

### DIFF
--- a/Node.js/README.md
+++ b/Node.js/README.md
@@ -18,6 +18,12 @@ Download and install [nvm](https://github.com/nvm-sh/nvm) by running:
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 ```
 
+or via Homebrew:
+
+```sh
+brew install nvm
+```
+
 Then download Node and select your version by running:
 
 ```sh


### PR DESCRIPTION
There is a homebrew [formula](https://formulae.brew.sh/formula/nvm) for nvm. It is not "officially" supported by nvm, but it's always in line with the stable version. 

It works well and I believe it's better to include it instead of just displaying a script for a specific (now outdated) version of nvm.