### PR TITLE
Calling brew cask install is deprecated from 2.6.0 (Dec 1st 2020)

### DIFF
--- a/PostgreSQL/README.md
+++ b/PostgreSQL/README.md
@@ -62,8 +62,8 @@ psql
 
 We can use `psequel` a free GUI tool for managing the local and remote PostgreSQL databases
 
-Install `psequel` using `homebrew` and `cask`
+Install `psequel` using `homebrew`
 
 ```sh
-brew cask install psequel
+brew install psequel
 ```


### PR DESCRIPTION
https://brew.sh/2020/12/01/homebrew-2.6.0/
> Today I’d like to announce Homebrew 2.6.0. [...] brew commands replacing all `brew cask` commands [...]

```
brew cask install psequel
Updating Homebrew...
...
> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

```
brew --version
Homebrew 2.6.1
```