### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Monthly, chosen randomly to avoid peak times
+    - cron:  '5 15 14 * *'
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '13'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          make deps
+
+      - name: Test
+        run: |
+          make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Test
 
-on:
-  push:
-  pull_request:
-  schedule:
-    # Monthly, chosen randomly to avoid peak times
-    - cron:  '5 15 14 * *'
+on: [push, pull_request]
 
 env:
   FORCE_COLOR: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-- 13
-install: make deps
-script: make ci

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MARKDOWNLINT	= $(shell command -v ./node_modules/.bin/markdownlint 2> /dev/null)
 YARN		= $(shell command -v yarn 2> /dev/null)
 
 
-# This is run on Travis to verify linting is OK and that the guide builds
+# This is run on CI to verify linting is OK and that the guide builds
 ci: lint
 	$(GITBOOK) install && $(GITBOOK) build
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | branch | status |
 | ------ | ------ |
-| `main` | [![main branch](https://travis-ci.org/sb2nov/mac-setup.svg?branch=main)](https://travis-ci.org/sb2nov/mac-setup) |
+| `main` | [![main branch](https://github.com/sb2nov/mac-setup/workflows/Test/badge.svg)](https://github.com/sb2nov/mac-setup/actions) |
 | `health-check` | [![health-check branch](https://img.shields.io/travis/sb2nov/mac-setup/health-check.svg?label=links)](https://travis-ci.org/sb2nov/mac-setup) |
 
 This guide covers the basics of setting up a development environment on a new


### PR DESCRIPTION
Travis CI are going to shut down travis-ci.org by the end of the year, all projects need to migrate over to travis-ci.com. They've been moving resources over, hence the slow builds on .org.

https://docs.travis-ci.com/user/migrate/open-source-repository-migration

However, on .com there's a new pricing model. You'll get a certain number of credits to begin with. When they run out, you can either pay to subscribe, or contact support to apply for their new open source plan.

https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

However, there are huge delays in support replying, if ever, and when they do they say they're waiting for approval from management, or someone recently was told that things are on hold pending more info from management.

I ran out of credits so couldn't build anything for two weeks. Support then gave me a one-off top-up of 50k credits whilst still awaiting approval from management. I've not heard anything in 9 days.

The new pricing model was launched with no notice, meaning some projects that had already migrated no longer have the choice of very slow builds on .org, or no builds on .com.

The mixed messaging and especially lack of communication, coupled with builds stopping altogether, means many open-source projects are moving to other CI providers, such as GitHub Actions.

Sample run:

* https://github.com/hugovk/mac-setup/runs/1546417059?check_suite_focus=true