### PR TITLE
Use Github action for link validator

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,33 @@
+name: Links
+
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Find markdown files
+        shell: bash
+        run: |
+          echo 'FILES_TO_CHECK<<EOF' >> $GITHUB_ENV
+
+          # $GITHUB_WORKSPACE is where our files live
+          # Ignore dirs and only include markdown files
+
+          files_to_check=$(find $GITHUB_WORKSPACE -type f \
+          -not -path '*/\.git/*' -not -path '*/\.github/*' \
+          -name "*.md")
+
+          echo $files_to_check >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Validate that links are up
+        uses: simeg/urlsup-action@v1.0.0
+        with:
+          args: ${{ env.FILES_TO_CHECK }} --threads 10 --allow 429 --white-list http://localhost

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # [macOS Setup Guide](https://sourabhbajaj.com/mac-setup)
 
-| branch | status |
-| ------ | ------ |
-| `main` | [![main branch](https://github.com/sb2nov/mac-setup/workflows/Test/badge.svg)](https://github.com/sb2nov/mac-setup/actions) |
-| `health-check` | [![health-check branch](https://img.shields.io/travis/sb2nov/mac-setup/health-check.svg?label=links)](https://travis-ci.org/sb2nov/mac-setup) |
+[![Test](https://github.com/sb2nov/mac-setup/workflows/Test/badge.svg)](https://github.com/sb2nov/mac-setup/actions?query=workflow%3ATest) [![Links](https://github.com/sb2nov/mac-setup/workflows/Links/badge.svg)](https://github.com/sb2nov/mac-setup/actions?query=workflow%3ALinks)
 
 This guide covers the basics of setting up a development environment on a new
 Mac. Whether you are an experienced programmer or not, this guide is intended


### PR DESCRIPTION
I figured out how to use urlsup with a decent API so we can migrate away
from Travis CI and instead use Github actions.

After this PR is merged:
- [ ] Delete the `health-check` branch, removing all dependencies to Travis CI from this project

cc @sb2nov @hugovk [at]anyone else that has input