### PR TITLE
Remove suggested Total Finder changes.

### DIFF
--- a/Apps/Settings.md
+++ b/Apps/Settings.md
@@ -31,14 +31,3 @@ These settings are optional. Some of them are highly subjective and should not b
 ## Timing
 
 - System Preferences -> Security and Privacy -> Accessibility -> Check
-
-## Total Finder
-
-- General -> New finder window opens in the home folder
-- Sidebar -> Remove shared devices and All my files
-- Advanced -> Search in the current directory
-- TotalFinder
-  - Show progress bar
-  - Menus -> Show cut-copy-paste, All path copying, hide menu bar icon
-  - Uncheck visor
-  - Folder on top


### PR DESCRIPTION
Since e62d3b1754baabc8927d920e971fe11f1b717b6a Total Finder is no longer suggested to be installed and it is also discontinued(no support for Apple Silicon and upcoming versions of MacOS). I don't think this should be recommended for newly installed Macs, even if Total Finder is a nice addition. 

Post about the future of Total Finder: https://blog.binaryage.com/totalfinder-totalspaces-future/