### PR TITLE
Replace deprecated quick look extensions & minor housekeeping for checks

### DIFF
--- a/Homebrew/Cask.md
+++ b/Homebrew/Cask.md
@@ -25,15 +25,11 @@ JSON, patch files, CSV, ZIP files and more.
 
 ```sh
 brew install --cask \
-    qlcolorcode \
-    qlstephen \
     qlmarkdown \
-    quicklook-json \
-    qlprettypatch \
-    quicklook-csv \
     betterzip \
     webpquicklook \
-    suspicious-package
+    suspicious-package \
+    syntax-highlight 
 ```
 
 ### App Suggestions

--- a/Homebrew/Cask.md
+++ b/Homebrew/Cask.md
@@ -29,7 +29,7 @@ brew install --cask \
     betterzip \
     webpquicklook \
     suspicious-package \
-    syntax-highlight 
+    syntax-highlight
 ```
 
 ### App Suggestions

--- a/Node.js/README.md
+++ b/Node.js/README.md
@@ -81,6 +81,6 @@ npm uninstall [-g] <package>
 
 Yarn is package manager
 
-```
+```sh
 brew install yarn
 ```

--- a/iTerm/zsh.md
+++ b/iTerm/zsh.md
@@ -1,8 +1,8 @@
 # zsh
 
 The Z shell (also known as `zsh`) is a Unix shell that is built on top of `bash`
-and that, since macOS 10.15 Catalina, is the **default** shell for macOS. 
-Since it has many with additional features, _if you have a version of macOS older than Catalina_,  
+and that, since macOS 10.15 Catalina, is the **default** shell for macOS.
+Since it has many with additional features, _if you have a version of macOS older than Catalina_,
 it's recommended to use `zsh` over `bash`. In this case it's also highly recommended to install a framework with
 `zsh` as it makes dealing with configuration, plugins and themes a lot nicer.
 


### PR DESCRIPTION
Suggest replacing older plugins for macOS 10.15+ with [Syntax Highlight](https://github.com/sbarex/SourceCodeSyntaxHighlight): supports most programming languages by default, many additional features/customisation
