### PR TITLE
svn required for Source Code Pro; also updated the pref path

### DIFF
--- a/iTerm/README.md
+++ b/iTerm/README.md
@@ -17,10 +17,10 @@ brew install --cask iterm2
 Here are some suggested settings you can change or set, **they are all optional**.
 
 - Set hot-key to open and close the terminal to `command + option + i`
-- Go to profiles -> Default -> Terminal -> Check silence bell to disable the terminal session from making any sound
+- Go to `Preferences -> Profiles -> Default -> Terminal` and check `Silence bell` to disable the terminal session from making any sound
 - Download [one of iTerm2 color schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/schemes) and then set these to your default profile colors
 - Change the cursor text and cursor color to yellow make it more visible
-- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](https://sourabhbajaj.com/mac-setup/Homebrew/) `brew tap homebrew/cask-fonts && brew install --cask font-source-code-pro`
+- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](https://sourabhbajaj.com/mac-setup/Homebrew/) `brew tap homebrew/cask-fonts && brew install --cask font-source-code-pro`. Make sure you have svn installed using `brew install svn` before installing Source Code Pro
 - If you're using BASH instead of ZSH you can add `export CLICOLOR=1` line to your `~/.bash_profile` file for nice coloring of listings
 
 [![Screen](https://raw.githubusercontent.com/sb2nov/mac-setup/main/assets/Iterm.png)](https://raw.githubusercontent.com/sb2nov/mac-setup/main/assets/Iterm.png)


### PR DESCRIPTION
while doing the setup on a new M1Pro macbook, looks like svn is not installed by default but is a prerequisite for Source Code Pro. Updated the same and also made a slight correction to the preferences path where the silence bell option needs to be checked.
Thanks!