### PR TITLE
Refactor with correct homebrew package name

### DIFF
--- a/Rust/README.md
+++ b/Rust/README.md
@@ -9,7 +9,7 @@ allow you to switch between versions of Rust without having to download
 anything additional.
 
 ```sh
-brew install rustup
+brew install rustup-init
 ```
 
 Use rustup to install the Rust compiler (rustc) and the Rust package manager (cargo).


### PR DESCRIPTION
Although the package name "rustup" still works, in homebrew the new name for the same package is "rustup-init". See more (https://formulae.brew.sh/formula/rustup-init#default)