### PR TITLE
MySQL GUI Tool: Change from Sequel Pro to Sequel Ace

### DIFF
--- a/MyySQL/README.md
+++ b/MyySQL/README.md
@@ -48,10 +48,10 @@ mysql -uroot
 
 ## GUI Tool
 
-It is always nice to have a GUI tool for managing databases. For Mac, you can use [Sequel Pro](http://www.sequelpro.com/) to manage local and remote MySQL databases. It is a free tool, you can choose to donate to support the development.
+It is always nice to have a GUI tool for managing databases. For Mac, you can use [Sequel Ace](https://sequel-ace.com/) to manage local and remote MySQL databases. It is a free tool, you can choose to donate to support the development.
 
 You may install Sequel Pro using [Homebrew](https://sourabhbajaj.com/mac-setup/Homebrew/Cask.html):
 
 ```sh
-brew install --cask sequel-pro
+brew install --cask sequel-ace
 ```


### PR DESCRIPTION
Seque Pro has reached end of life, and Sequel Ace is a great (and very similar) tool that can be used in its place. See [this issue in the Sequel Pro project](https://github.com/sequelpro/sequelpro/issues/3705) for more info around that. 

## Reference 
https://github.com/Sequel-Ace/Sequel-Ace
https://formulae.brew.sh/cask/sequel-ace
https://github.com/sequelpro/sequelpro/issues/3705 