### PR TITLE
Fix broken links and update documentation

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -7,9 +7,18 @@ Here is a list of apps that are generally good to use and can come in handy in d
 
 ## Development Tools
 
+- [Brave Browser](https://brave.com/): A privacy-focused browser built on Chromium with built-in ad blocking and full Chrome DevTools.
 - [Google Chrome](https://www.google.com/intl/en/chrome/browser/): Chrome is a developer friendly browser with powerful development tools built in to it.
+- [Warp](https://www.warp.dev/): A modern terminal built on Rust with AI-powered command suggestions and collaborative features.
+- [Cursor](https://www.cursor.com/): An AI-powered code editor built on VS Code.
+- [Zed](https://zed.dev/): A high-performance code editor built in Rust with real-time collaboration.
+- [GitHub Desktop](https://desktop.github.com/): A GUI for Git that simplifies your development workflow.
 - [Valentina Studio](http://www.valentina-db.com/en/valentina-studio-overview): Valentina Studio is a GUI to create, administer and query MySQL, Postgres and SQLite databases.
-- [Atom](https://atom.io/): An open source editor built and maintained by GitHub, is very similar to Sublime Text in most aspects.
+
+## AI Tools
+
+- [Claude](https://claude.ai/): Anthropic's AI assistant desktop app.
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code): An agentic coding tool from Anthropic that lives in your terminal.
 
 ## Diff and Merge Tools
 
@@ -33,33 +42,34 @@ Here is a list of apps that are generally good to use and can come in handy in d
 
 - [P4Merge](http://www.perforce.com/product/components/perforce-visual-merge-and-diff-tools)
 - [DiffMerge](http://www.sourcegear.com/diffmerge/)
+
 Both of these tools can't compare in terms of features and user interface with their commercial competitors - but make for a valid alternative on Mac, Windows and Linux.
 
 ## Productivity
 
-- [1Password](https://1password.com): Cross platform password management tool.
-- [Airmail](http://airmailapp.com/): Lightweight fast email client.
-- [Alfred](http://www.alfredapp.com/): Spotlight on steroids.
+- [1Password](https://1password.com/): Cross platform password management tool.
+- [Raycast](https://www.raycast.com/): An extendable launcher and productivity tool. A modern alternative to Spotlight and Alfred.
 - [Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704): Stops the machine from going into sleep mode.
-- [AppCleaner](http://www.freemacsoft.net/appcleaner/): Uninstall apps.
-- [DoubleTwist](https://www.doubletwist.com/desktop/): Import your playlists, ratings, music and videos. Create new playlists to your heart's content. Rate your songs and videos. Play your music and videos and view all of your photos.
+- [AppCleaner](http://www.freemacsoft.net/appcleaner/): Uninstall apps cleanly.
 - [Dropbox](https://www.dropbox.com/): File syncing to the cloud. It syncs files across all devices (laptop, mobile, tablet), and serves as a backup as well!
-- [F.lux](https://justgetflux.com/): f.lux makes the color of your computer's display adapt to the time of day, warm at night and like sunlight during the day (If you are running macOS 10.12.4 or later there's native functionality called 'Night Shift' that does the same thing as f.lux, see System Preferences -> Displays -> Night Shift).
 - [Google Drive](https://drive.google.com/): File syncing to the cloud too! Google Docs is a popular tool to collaborate with others.
-- [Notebooks](http://www.notebooksapp.com/mac/): Notebooks for Mac allows you to share files with the mobile versions of Notebooks on the iPad and iPhone. And you can write notes in markdown.
-- [PDF Toolkit+](https://itunes.apple.com/us/app/pdf-toolkit-+/id545164971?mt=12): App to cut/split/merge pdfs easily. Really easy to use and works well.
-- [Pocket](https://getpocket.com): Save For Later. Put articles, videos or pretty much anything into Pocket. Save directly from your browser or from apps like Twitter, Flipboard, Pulse and Zite.
 - [Rectangle](https://github.com/rxhanson/Rectangle): Don't waste time resizing and moving your windows. Rectangle makes this very easy and is open source.
+- [Shottr](https://shottr.cc/): A small, fast, and feature-rich screenshot tool for Mac.
+- [Pocket](https://getpocket.com): Save For Later. Put articles, videos or pretty much anything into Pocket.
 - [Timing](http://timingapp.com/): Keep track of the time you spend with your Mac.
-- [Tomighty](https://tomighty.github.io/): A free desktop timer for the Pomodoro Technique.
-- [Total Finder](http://totalfinder.binaryage.com/): Adds tabs and improves the Finder to a great deal.
 - [Transmission](http://www.transmissionbt.com/): A fast, easy and free BitTorrent client.
-- [Unarchiver](http://wakaba.c3.cx/s/apps/unarchiver.html): Compress/Uncompress app. Supported file formats include Zip, Tar-GZip, Tar-BZip2, RAR, 7-zip, LhA, StuffIt and many other old and obscure formats.
+- [Unarchiver](https://theunarchiver.com/): Compress/Uncompress app. Supported file formats include Zip, Tar-GZip, Tar-BZip2, RAR, 7-zip, LhA, StuffIt and many other old and obscure formats.
+
+## Communication
+
+- [Slack](https://slack.com/): Team messaging and collaboration.
+- [WhatsApp](https://www.whatsapp.com/): Desktop client for WhatsApp messaging.
+- [Spotify](https://www.spotify.com/): Music streaming.
 
 ## Office Apps
 
 - [Keynote](http://www.apple.com/mac/keynote/): Create presentations on Mac, this is supposed to be an alternate to PowerPoint.
-- [Microsoft Office](http://www.microsoft.com/mac/buy): Microsoft Office for Mac. Includes Microsoft Word, Excel, PowerPoint and Outlook.
+- [Microsoft Office](https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac): Microsoft Office for Mac. Includes Microsoft Word, Excel, PowerPoint and Outlook.
 - [Numbers](http://www.apple.com/mac/numbers/): Create spreadsheets on Mac, this is supposed to be an alternate to Excel.
 - [Pages](http://www.apple.com/mac/pages/): Create text files on Mac, this is supposed to be an alternate to Word.
 
@@ -69,4 +79,3 @@ Both of these tools can't compare in terms of features and user interface with t
 - [SuperDuper](http://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html): Take backups of your disk and use the backup disk to restore the machine in case of failure.
 - [TimeOut](http://www.dejal.com/timeout/): Scheduled work breaks to prevent stress injuries.
 - [VLC](http://www.videolan.org/vlc/index.html): VLC Media Player. Enough said.
-- [Voila](http://www.globaldelight.com/voila/): Record your screen with audio, mouse highlight and other features.

--- a/docs/bash-completion.md
+++ b/docs/bash-completion.md
@@ -7,24 +7,36 @@ Bash completion is a bash function that allows you to auto complete commands or
 arguments by typing partially commands or arguments, then pressing the [Tab]
 key. This will help you when writing the bash command in terminal.
 
-## Installation
+## Install Latest Bash
+
+macOS ships with an outdated version of Bash (3.2). You can install the latest
+version using Homebrew:
 
 ```sh
-brew install bash-completion
+brew install bash
 ```
 
-Bash completion will be installed in `/usr/local/etc/bash_completion.d`.
+To use the Homebrew-installed Bash as your default shell, add it to the list of
+allowed shells and set it:
+
+```sh
+sudo sh -c 'echo "$(brew --prefix)/bin/bash" >> /etc/shells'
+chsh -s "$(brew --prefix)/bin/bash"
+```
+
+## Installation
+
+Use `bash-completion@2`, which is designed for Bash 4.2+ (the version installed
+by Homebrew):
+
+```sh
+brew install bash-completion@2
+```
 
 For it to work, add this to your `~/.bash_profile`:
 
 ```sh
-[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
-```
-
-Or simply type:
-
-```sh
-echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> ~/.bash_profile
+[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
 ```
 
 Restart your bash session:
@@ -49,7 +61,7 @@ bisect         cherry         commit         fetch          grep           log  
 
 ## More
 
-You can list additional completion packages are available by typing:
+You can list additional completion packages available by typing:
 
 ```sh
 brew search completion
@@ -60,6 +72,3 @@ And you can install them using `brew install` commands, for example:
 ```sh
 brew install docker-completion
 ```
-
-*You can also manually add a bash completion file into
-`/usr/local/etc/bash_completion.d`*

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -3,19 +3,19 @@ title: C++
 ---
 
 
-Make sure you have installed [Xcode Command Line Tools](/xcode). Check the C++ version to make sure it is Clang 4.0+.
+Make sure you have installed [Xcode Command Line Tools](/xcode). Verify the compiler is available:
 
 ```console
 $ c++ --version
-Apple LLVM version 5.1 (clang-503.0.38) (based on LLVM 3.4svn)
-Target: x86_64-apple-darwin13.1.0
+Apple clang version 16.0.0 (clang-1600.0.26.6)
+Target: arm64-apple-darwin24.3.0
 Thread model: posix
 ```
 
-To be able to compile files from your terminal you can add the following alias in your `env.sh` file.
+To be able to compile files from your terminal you can add the following alias in your shell configuration file (e.g. `~/.zshrc`).
 
 ```sh
-alias cppcompile='c++ -std=c++11 -stdlib=libc++'
+alias cppcompile='c++ -std=c++17 -stdlib=libc++'
 ```
 
-Then you can run all cpp file directly using `cppcompile main.cpp` and it will use C++11 so no errors in the case of using vectors, auto, sets etc.
+Then you can run all cpp file directly using `cppcompile main.cpp` and it will use C++17.

--- a/docs/docker/index.md
+++ b/docs/docker/index.md
@@ -5,77 +5,29 @@ title: Docker
 
 [Docker](https://docs.docker.com) is a platform for developers and sysadmins to develop, ship, and run applications. Docker lets you quickly assemble applications from components and eliminates the friction that can come when shipping code. Docker lets you get your code tested and deployed into production as fast as possible.
 
-With Docker, developers can build any app in any language using any toolchain. “Dockerized” apps are completely portable and can run anywhere - colleagues’ macOS and Windows laptops, QA servers running Ubuntu in the cloud, and production data center VMs running Red Hat.
+With Docker, developers can build any app in any language using any toolchain. "Dockerized" apps are completely portable and can run anywhere - colleagues' macOS and Windows laptops, QA servers running Ubuntu in the cloud, and production data center VMs running Red Hat.
 
-## Docker for Mac
+## Installation
 
-Docker for Mac is the current release of Docker for macOS.
+The recommended way to use Docker on macOS is via **Docker Desktop**.
 
-### Installation
-
-[Download Docker for Mac here](https://docs.docker.com/docker-for-mac/install/).
-
-### Prerequisite
-
-You'll need `homebrew-cask` to install Docker Toolbox, if you don't have it refer to [this section](/homebrew/cask).
-
-### Installation
-
-There are two ways to install Docker
-
-Option 1: These are the steps to install docker using brew
-
-* Install the docker and docker machine from brew
+### Using Homebrew
 
 ```sh
-brew install docker docker-machine
+brew install --cask docker
 ```
 
-* Install VirtualBox to let Docker create the images.
+### Manual Download
+
+Alternatively, download Docker Desktop from the [official website](https://www.docker.com/products/docker-desktop/).
+
+### Verify Installation
+
+After installing and launching Docker Desktop, verify the installation:
 
 ```sh
-brew install --cask virtualbox
-```
-
->If you encounter an issue with the installer with an error message like
-
-```sh
-The install failed (The installer encountered an error that caused the installation to fail.
-Contact the software manufacturer for assistance.)
-```
-
->Use the following When you do fail, turn on System Preference and see if ‘System software from developer “Oracle America, inc” was blocked from loading.’ If you see that message, click Allow button and try to install again.
-
-This should complete the installation
-
----
-
-Now to create a Machine, follow the following steps:
-
-```sh
-docker-machine create --driver virtualbox default
-```
-
-Run the following to tell Docker which machine to execute Docker on
-
-```sh
-docker-machine env default
-```
-
-Finally, to verify all the installations:
-
-```sh
+docker --version
 docker run hello-world
 ```
 
 You can find more about Docker in the [documentation](https://docs.docker.com/).
-
-Option 2: Install using the Docker App
-
-* Navigate to the following link
-
-```sh
-https://hub.docker.com/editions/community/docker-ce-desktop-mac/
-```
-
-This installation should provide you all the necessary GUI tools

--- a/docs/emacs.md
+++ b/docs/emacs.md
@@ -5,7 +5,7 @@ title: Emacs
 
 [Emacs](https://www.gnu.org/software/emacs/) is a family of text editors that are characterized by their extensibility. The manual for the most widely used variant, GNU Emacs, describes it as the extensible, customizable, self-documenting, real-time display editor.
 
-Development of the first Emacs began in the mid-1970s, and work on its direct descendant, GNU Emacs, continues actively as of 2017.
+Development of the first Emacs began in the mid-1970s, and work on its direct descendant, GNU Emacs, continues actively.
 
 ## Installation
 
@@ -59,25 +59,13 @@ Start off by tapping the official emacs-plus cask.
 brew tap d12frosted/emacs-plus
 ```
 
-Emacs Plus contains separate formulas for different Emacs versions:
-
-* emacs-plus - installs Emacs 26, current release version.
+Install the latest version of Emacs Plus:
 
 ```sh
 brew install emacs-plus [options]
 ```
 
-* emacs-plus@27 - installs Emacs 27, next release version.
-
-```sh
-brew install emacs-plus@27 [options]
-```
-
-* emacs-plus@28 - installs Emacs 28, development version.
-
-```sh
-brew install emacs-plus@28 [options]
-```
+You can also install specific versions (e.g. `emacs-plus@29`, `emacs-plus@30`).
 
 <details>
 <summary>Click here to see available options: </summary>
@@ -170,17 +158,13 @@ Upon starting up Emacs for the first time, further third-party packages will be 
 
 ## Doom Emacs
 
-[Doom](https://github.com/hlissner/doom-emacs) is a configuration for GNU Emacs written by a stubborn, shell-dwelling, and melodramatic ex-vimmer. It wasn't originally intended for public use, but can be considered a hacker's starter kit.
+[Doom Emacs](https://github.com/doomemacs/doomemacs) is a configuration framework for GNU Emacs. It can be considered a hacker's starter kit.
 
 ### Installation
 
 ```sh
-git clone https://github.com/hlissner/doom-emacs ~/.emacs.d
-cd ~/.emacs.d
-cp init.example.el init.el  # maybe edit init.el
-make install
+git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
+~/.config/emacs/bin/doom install
 ```
 
-Don't forget to run `make` every time you modify `init.el`!
-
-Visit the wiki for [a more detailed guide on installing, customizing and grokking Doom](https://github.com/hlissner/doom-emacs/wiki).
+Visit the [documentation](https://github.com/doomemacs/doomemacs/blob/master/docs/getting_started.org) for a more detailed guide on installing and customizing Doom.

--- a/docs/git/index.md
+++ b/docs/git/index.md
@@ -15,7 +15,30 @@ When done, to test that it installed properly you can run:
 git --version
 ```
 
-And `which git` should output `/usr/local/bin/git`.
+And `which git` should output `/opt/homebrew/bin/git` (Apple Silicon) or `/usr/local/bin/git` (Intel).
+
+### Git LFS
+
+[Git Large File Storage](https://git-lfs.github.com/) replaces large files with text pointers inside Git while storing the file contents on a remote server.
+
+```sh
+brew install git-lfs
+git lfs install
+```
+
+### GitHub CLI
+
+The [GitHub CLI](https://cli.github.com/) (`gh`) brings GitHub to your terminal. You can create PRs, review code, manage issues, and more without leaving the command line.
+
+```sh
+brew install gh
+```
+
+Authenticate with your GitHub account:
+
+```sh
+gh auth login
+```
 
 Next, we'll define your Git user (should be the same name and email you use for [GitHub](https://github.com/)):
 
@@ -26,7 +49,7 @@ git config --global user.email "your_email@youremail.com"
 
 They will get added to your `.gitconfig` file.
 
-To push code to your GitHub repositories, we will use the recommended HTTPS method. There are also instructions for using SSH. To prevent `git` from asking for your username and password every time you push a commit you can cache your credentials by running the following command, as described in the [instructions](https://help.github.com/articles/caching-your-github-password-in-git/).
+To push code to your GitHub repositories, we will use the recommended HTTPS method. There are also instructions for using SSH. To prevent `git` from asking for your username and password every time you push a commit you can cache your credentials by running the following command, as described in the [instructions](https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git).
 
 ```sh
 git config --global credential.helper osxkeychain
@@ -34,7 +57,7 @@ git config --global credential.helper osxkeychain
 
 ## Using HTTPS for GitHub (recommended)
 
-These instructions are from [the official documentation](https://help.github.com/en/github/using-git/which-remote-url-should-i-use#cloning-with-https-urls-recommended).
+These instructions are from [the official documentation](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls).
 
 ### Clone repositories using HTTPS
 
@@ -54,12 +77,12 @@ If you are setting up a new repo, add at least one file and commit first. Then, 
 
 ```sh
 git remote add origin https://github.com/<username>/<repo-name>.git
-git push -u origin master
+git push -u origin main
 ```
 
 ## SSH Config for GitHub
 
-These instructions are for those who wish to use SSH and not HTTPS, and are from [the official documentation](https://help.github.com/articles/generating-ssh-keys).
+These instructions are for those who wish to use SSH and not HTTPS, and are from [the official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
 
 ### Check for existing SSH keys
 
@@ -70,14 +93,14 @@ ls -al ~/.ssh
 # Lists the files in your .ssh directory, if they exist
 ```
 
-Check the directory listing to see if you have files named either `id_rsa.pub` or `id_dsa.pub`. If you don't have either of those files then read on, otherwise skip the next section.
+Check the directory listing to see if you have files named either `id_ed25519.pub` or `id_rsa.pub`. If you don't have either of those files then read on, otherwise skip the next section.
 
 ### Generate a new SSH key
 
 If you don't have an SSH key you need to generate one. To do that you need to run the commands below, and make sure to substitute the placeholder with your email. The default settings are preferred, so when you're asked to enter a file in which to save the key, just press Enter to continue.
 
 ```sh
-ssh-keygen -t rsa -C "your_email@example.com"
+ssh-keygen -t ed25519 -C "your_email@example.com"
 # Creates a new ssh key, using the provided email as a label
 ```
 
@@ -89,19 +112,19 @@ Run the following commands to add your SSH key to the `ssh-agent`.
 eval "$(ssh-agent -s)"
 ```
 
-If you're running macOS Sierra 10.12.2 or later, you will need to modify your `~/.ssh/config` file to automatically load keys into the ssh-agent and store passphrases in your keychain:
+Modify your `~/.ssh/config` file to automatically load keys into the ssh-agent and store passphrases in your keychain:
 
 ```ssh-config
 Host *
   AddKeysToAgent yes
   UseKeychain yes
-  IdentityFile ~/.ssh/id_rsa
+  IdentityFile ~/.ssh/id_ed25519
 ```
 
-No matter what operating system version you run you need to run this command to complete this step:
+Then add your SSH key to the ssh-agent:
 
 ```sh
-ssh-add -K ~/.ssh/id_rsa
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
 ```
 
 ### Adding a new SSH key to your GitHub account
@@ -109,7 +132,7 @@ ssh-add -K ~/.ssh/id_rsa
 The last step is to let GitHub know about your SSH key so GitHub can recognize you. Run this command to copy your key to your clipboard:
 
 ```sh
-pbcopy < ~/.ssh/id_rsa.pub
+pbcopy < ~/.ssh/id_ed25519.pub
 ```
 
 Then go to GitHub and [input your new SSH key](https://github.com/settings/ssh/new). Paste your key in the "Key" text-box and pick a name that represents the computer you're currently using.
@@ -134,5 +157,5 @@ If you are setting up a new repo, add at least one file and commit first. Then, 
 
 ```sh
 git remote add origin git@github.com:<username>/<repo-name>.git
-git push -u origin master
+git push -u origin main
 ```

--- a/docs/go.md
+++ b/docs/go.md
@@ -3,11 +3,11 @@ title: Go
 ---
 
 
-[Go](https://golang.org) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
+[Go](https://go.dev) is an open source programming language that makes it easy to build simple, reliable, and efficient software.
 
 ## Installation
 
-You can follow the [official instructions on how to install Go](https://golang.org/doc/install), or you can use Homebrew instead:
+You can follow the [official instructions on how to install Go](https://go.dev/doc/install), or you can use Homebrew instead:
 
 ```sh
 brew install go
@@ -15,34 +15,22 @@ brew install go
 
 When installed, run `go version` to see the installed version of Go.
 
-```sh
-$ go version
-go version go1.11.4 darwin/amd64
-```
-
-## Setup your workspace
-
-### The GOPATH and PATH environment variables
-
-The `GOPATH` environment variable specifies the location of your workspace. It defaults to a directory named `go` inside your home directory (`$HOME/go`).
-
-If you really want to change your GOPATH to something else add GOPATH to your shell/bash/zsh initialization file `.bash_profile`, `.bashrc` or `.zshrc`.
-
-```sh
-export GOPATH=/something-else
-```
-
-Add `GOPATH/bin` directory to your `PATH` environment variable so you can run Go programs anywhere.
+Add `GOPATH/bin` directory to your `PATH` environment variable so you can run Go programs anywhere. Add this to your `~/.zshrc` (or `~/.bash_profile`):
 
 ```sh
 export PATH=$PATH:$(go env GOPATH)/bin
 ```
 
-Make sure to re-source `source .bash_profile` your current session or simply open new tab within iTerm.
-
 ## Write your first program
 
-Create a file in your workspace `$GOPATH/src/hello/main.go` and add some code, for example:
+Modern Go uses **modules** for dependency management. Create a new project:
+
+```sh
+mkdir hello && cd hello
+go mod init hello
+```
+
+Create a file `main.go`:
 
 ```go
 package main
@@ -55,34 +43,13 @@ func main() {
 Run the program by running:
 
 ```console
-$ go run hello.go
-Hello World!
-```
-
-If you wish to compile it and move it to `$GOPATH/bin`, then run:
-
-```sh
-go install .
-```
-
-Since you have `$GOPATH/bin` added to your `$PATH`, you can run your program from anywhere:
-
-```console
-$ hello
+$ go run .
 Hello World!
 ```
 
 ## Import a Go package
 
-Besides creating your own packages you can import and use other packages in your Go code. To do so you'll use the `go get` command:
-
-```sh
-go get -u github.com/gorilla/mux
-```
-
-The command above will import the package `mux` into this directory `$GOPATH/src/github.com/gorilla/mux`.
-
-You can then use this package in your Go programs like this:
+With Go modules, you simply import packages in your code and run `go mod tidy` to download them:
 
 ```go
 package main
@@ -106,6 +73,14 @@ func main() {
 }
 ```
 
+Then run:
+
+```sh
+go mod tidy
+```
+
+This will automatically download and add the dependency to your `go.mod` file.
+
 ## Tooling and learning
 
 ### Format your code
@@ -124,21 +99,6 @@ You can also format an entire package:
 go fmt path/to/your/package
 ```
 
-> **Note**: that the command is different from formatting a single file
-
-### Generate documentation
-
-With the `godoc` command you can generate documentation from your code and read documentation from other packages.
-
-```sh
-godoc fmt                # documentation for package fmt
-godoc fmt Printf         # documentation for fmt.Printf
-godoc -src fmt           # fmt package interface in Go source form
-godoc -all -http :1234   # documentation for all packages on your machine served through http http://localhost:1234
-```
-
-You need to respect some spec in order to document using `godoc`. More information in the [Godoc documentation](https://blog.golang.org/godoc-documenting-go-code).
-
 ### Learn more
 
-The [interactive tutorial](https://tour.golang.org/) will let you learn more about Go. You can also install it locally by `go get golang.org/x/tour` and running it anywhere by `tour` (given that you added `GOPATH/bin` to your `PATH`).
+The [interactive tutorial](https://go.dev/tour/) will let you learn more about Go.

--- a/docs/homebrew/cask.md
+++ b/docs/homebrew/cask.md
@@ -5,7 +5,7 @@ title: Cask
 
 [Homebrew-Cask](https://github.com/Homebrew/homebrew-cask) extends Homebrew and allows you to
 install large binary files via a command-line tool. You can for example install
-applications like Google Chrome, Dropbox, VLC and Spectacle. No more
+applications like Brave Browser, Slack, VLC and Rectangle. No more
 downloading `.dmg` files and dragging them to your Applications folder!
 
 ## Search
@@ -35,27 +35,70 @@ brew install --cask \
     syntax-highlight
 ```
 
-### App Suggestions
+### Browsers
 
-Here are some useful apps that are available on Cask.
+```sh
+brew install --cask brave-browser
+```
+
+### Terminals
+
+```sh
+brew install --cask warp
+```
+
+### Editors and IDEs
 
 ```sh
 brew install --cask \
-    alfred \
-    android-file-transfer \
-    appcleaner \
-    caffeine \
-    cheatsheet \
-    docker \
-    doubletwist \
-    dropbox \
-    google-chrome \
-    flux \
-    1password \
+    cursor \
+    zed \
+    sublime-text
+```
+
+### AI Tools
+
+```sh
+brew install --cask \
+    claude \
+    claude-code
+```
+
+### Productivity
+
+```sh
+brew install --cask \
+    raycast \
     rectangle \
-    sublime-text \
-    superduper \
+    caffeine \
+    shottr \
+    appcleaner
+```
+
+### Developer Tools
+
+```sh
+brew install --cask \
+    docker \
+    github \
+    conductor
+```
+
+### Communication and Media
+
+```sh
+brew install --cask \
+    slack \
+    whatsapp \
+    spotify
+```
+
+### Other Useful Apps
+
+```sh
+brew install --cask \
+    1password \
+    dropbox \
     transmission \
-    valentina-studio \
     vlc
 ```

--- a/docs/homebrew/index.md
+++ b/docs/homebrew/index.md
@@ -10,42 +10,33 @@ macOS_ and is an essential tool for any developer.
 
 Before you can run Homebrew you need to have the **Command Line Tools for
 Xcode** installed. It include compilers and other tools that will allow you
-to build things from source, and if you are missing this it's available
-through the App Store > Updates. You can also install it from the terminal
+to build things from source. You can install it from the terminal
 by running the following:
 
 ```sh
-sudo xcode-select --install
+xcode-select --install
 ```
 
 To install Homebrew run the following in a terminal:
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 hit **Enter**, and follow the steps on the screen.
 
 ### Setting up your `PATH`
 
-To make the Homebrew-installed programs available in your shell, you need to add
-your Homebrew installation location to your `$PATH`. This is done for you already on
-macOS 10.14 Mojave and newer. For older versions of macOS, do the following:
-
-You change your path by adding `/usr/local/bin` to your `PATH` environment variable.
-This can be done on a per-user basis by adjusting `PATH` in your `~/.bash_profile`.
-To do this, run:
+On Apple Silicon Macs (M1/M2/M3/M4), Homebrew installs to `/opt/homebrew`. The
+installer will print instructions to add Homebrew to your `PATH`. Typically you
+need to add this to your `~/.zprofile` (or `~/.bash_profile` if using Bash):
 
 ```sh
-echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
-(If you're using `zsh`, you should do this for `~/.zshrc` in addition to
-`~/.bash_profile`.)
-
-Alternatively, you can also insert `/usr/local/bin` before the first line of
-`/etc/paths` to change the global default paths order, for all users and all
-major shells. An admin password will be required if you modify the file.
+On Intel Macs, Homebrew installs to `/usr/local` and is generally already on
+your `PATH`.
 
 Then, to be able to use `brew` you need to start a new terminal session. After that
 you should make sure everything is working by running:

--- a/docs/homebrew/usage.md
+++ b/docs/homebrew/usage.md
@@ -19,9 +19,9 @@ brew update
 formulas like this:
 
 ```sh
-cd /usr/local/Homebrew/
+cd "$(brew --prefix)/Homebrew/"
 git fetch origin
-git reset --hard origin/master
+git reset --hard origin/main
 ```
 
 To see if any of your formulas need to be updated:
@@ -74,3 +74,33 @@ To uninstall a formula you can run:
 ```sh
 brew uninstall <formula>
 ```
+
+## Recommended Formulas
+
+Here are some useful formulas for enhancing your command-line experience:
+
+### Core Utilities
+
+macOS ships with outdated or BSD versions of many command-line tools. These formulas install the latest GNU versions:
+
+```sh
+brew install \
+    coreutils \
+    moreutils \
+    findutils \
+    gnu-sed \
+    grep \
+    wget \
+    bash \
+    base64
+```
+
+> **Note**: GNU tools are installed with a `g` prefix by default (e.g. `gsed`, `gfind`). To use them without the prefix, add their `libexec/gnubin` directories to your `PATH`. For example, Homebrew will display instructions after installing each formula.
+
+### Search Tools
+
+```sh
+brew install the_silver_searcher
+```
+
+[The Silver Searcher](https://github.com/ggreer/the_silver_searcher) (`ag`) is a code searching tool similar to `ack`, but faster.

--- a/docs/iterm/ack.md
+++ b/docs/iterm/ack.md
@@ -68,5 +68,16 @@ ack --dump
 
 ## Alternatives to `ack`
 
-There's [The Silver Surfer](https://github.com/ggreer/the_silver_searcher) which describes itself as a
-> A code searching tool similar to `ack`, with a focus on speed.
+### The Silver Searcher
+
+[The Silver Searcher](https://github.com/ggreer/the_silver_searcher) (`ag`) is a code searching tool similar to `ack`, with a focus on speed.
+
+```sh
+brew install the_silver_searcher
+```
+
+Usage is similar to `ack`:
+
+```sh
+ag pancakes
+```

--- a/docs/iterm/fzf.md
+++ b/docs/iterm/fzf.md
@@ -19,7 +19,7 @@ brew install fzf
 If you want to use shell extensions (better shell integration):
 
 ```sh
-/usr/local/opt/fzf/install
+$(brew --prefix)/opt/fzf/install
 ```
 
 which gives you:

--- a/docs/iterm/index.md
+++ b/docs/iterm/index.md
@@ -23,7 +23,7 @@ Here are some suggested settings you can change or set, **they are all optional*
 - Go to profiles -> Default -> Terminal -> Check silence bell to disable the terminal session from making any sound
 - Download [one of iTerm2 color schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/schemes) and then set these to your default profile colors
 - Change the cursor text and cursor color to yellow make it more visible
-- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](/homebrew) `brew tap homebrew/cask-fonts && brew install --cask font-source-code-pro`
+- Change the font to 14pt Source Code Pro Lite. Source Code Pro can be downloaded using [Homebrew](/homebrew) `brew install --cask font-source-code-pro`
 - If you're using BASH instead of ZSH you can add `export CLICOLOR=1` line to your `~/.bash_profile` file for nice coloring of listings
 
 [![Screen](https://raw.githubusercontent.com/sb2nov/mac-setup/refs/heads/main/static/assets/Iterm.png)](https://raw.githubusercontent.com/sb2nov/mac-setup/refs/heads/main/static/assets/Iterm.png)

--- a/docs/iterm/zsh.md
+++ b/docs/iterm/zsh.md
@@ -4,10 +4,9 @@ title: Zsh
 
 
 The Z shell (also known as `zsh`) is a Unix shell that is built on top of `bash`
-and that, since macOS 10.15 Catalina, is the **default** shell for macOS.
-Since it has many with additional features, _if you have a version of macOS older than Catalina_,
-it's recommended to use `zsh` over `bash`. In this case it's also highly recommended to install a framework with
-`zsh` as it makes dealing with configuration, plugins and themes a lot nicer.
+and is the **default** shell for macOS (since Catalina). It's highly recommended
+to install a framework with `zsh` as it makes dealing with configuration,
+plugins and themes a lot nicer.
 
 We've also included an `env.sh` file where we store our aliases, exports, path
 changes etc. We put this in a separate file to not pollute our main
@@ -19,7 +18,7 @@ Install `zsh` using Homebrew:
 brew install zsh
 ```
 
-Now you should install a framework, we recommend to use [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh)
+Now you should install a framework, we recommend to use [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh)
 or [Prezto](https://github.com/sorin-ionescu/prezto). **Note that you should
 pick one of them, not use both.**
 
@@ -28,14 +27,14 @@ folder (`~/.zshrc`).
 
 ## Oh My Zsh
 
-[Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh) is an open source,
+[Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh) is an open source,
 community-driven framework for managing your `zsh` configuration. It comes
 with a bunch of features out of the box and improves your terminal experience.
 
 Install Oh My Zsh:
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 ```
 
 The installation script should set `zsh` to your default shell, but if it
@@ -48,7 +47,7 @@ chsh -s $(which zsh)
 ### Configuration
 
 The out-of-the-box configuration is usable but you probably want to customise
-it to suit your needs. The [Official Wiki](https://github.com/robbyrussell/oh-my-zsh/wiki)
+it to suit your needs. The [Official Wiki](https://github.com/ohmyzsh/ohmyzsh/wiki)
 contains a lot of useful information if you want to deep dive into what you
 can do with Oh My Zsh, but we'll cover the basics here.
 
@@ -68,7 +67,7 @@ array in your `.zshrc`.
 plugins=(git colored-man-pages colorize pip python brew macos)
 ```
 
-You'll find a list of all plugins on the [Oh My Zsh Wiki](https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins).
+You'll find a list of all plugins on the [Oh My Zsh Wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Plugins).
 Note that adding plugins can cause your shell startup time to increase.
 
 ##### zsh-syntax-highlighting
@@ -111,7 +110,7 @@ ZSH_THEME=pygmalion
 ```
 
 You'll find a list of themes with screenshots on the
-[Oh My Zsh Wiki](https://github.com/robbyrussell/oh-my-zsh/wiki/themes).
+[Oh My Zsh Wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/themes).
 
 ## Prezto
 

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -8,7 +8,7 @@ We'll use a JDK since it can do everything a JRE can, plus more.
 
 ## Choosing a JDK
 
-As of 2019, there are two major JDKs: OpenJDK (also known as AdoptOpenJDK) and the Oracle JDK.
+There are two major JDKs: OpenJDK and the Oracle JDK.
 OpenJDK and Oracle JDK provide the same functionality, and are even built from the same code base.
 They differ only in their packaging and licensing.
 
@@ -29,9 +29,9 @@ java -version
 If you see a non-empty output like below then Java is already installed on your machine and you are good to go
 
 ```sh
-openjdk version "13.0.2" 2020-01-14
-OpenJDK Runtime Environment AdoptOpenJDK (build 13.0.2+8)
-OpenJDK 64-Bit Server VM AdoptOpenJDK (build 13.0.2+8, mixed mode, sharing)
+openjdk version "21.0.2" 2024-01-16
+OpenJDK Runtime Environment Homebrew (build 21.0.2)
+OpenJDK 64-Bit Server VM Homebrew (build 21.0.2, mixed mode, sharing)
 ```
 
 If you don't see the output like above then you need to install Java on your system
@@ -56,7 +56,6 @@ Once you've done that, check if Java is correctly installed by running the `java
 
 #### Downloading and installing OpenJDK manually
 
-Open a web browser and go to [https://adoptopenjdk.net/](https://adoptopenjdk.net/). Select "OpenJDK 11 (LTS)" and "HotSpot".
-Click the big "Latest release" button and run the installer file that gets downloaded.
+Open a web browser and go to [Adoptium](https://adoptium.net/). Select the latest LTS version and download the installer for macOS.
 
 Once you've done that, check if Java is correctly installed by opening a new Terminal session and running the `java -version` command again.

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -7,8 +7,6 @@ title: MySQL
 
 We will install MySQL using Homebrew, which will also install some header files needed for MySQL bindings in different programming languages (MySQL-Python for one).
 
-> **Note**: Sequel Pro does not support latest MySQL (version 8), because of that you may want to install MySQL 5.7 instead - `brew install mysql@5.7`.
-
 ```sh
 brew install mysql
 ```

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -18,7 +18,7 @@ brew install node
 Download and install [nvm](https://github.com/nvm-sh/nvm) by running:
 
 ```sh
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ```
 
 or via Homebrew:
@@ -48,12 +48,6 @@ To install a package:
 ```sh
 npm install <package> # Install locally
 npm install -g <package> # Install globally
-```
-
-To install a package and save it in your project's `package.json` file:
-
-```sh
-npm install <package> --save
 ```
 
 To see what's installed:

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -8,7 +8,7 @@ PostgreSQL is an open source relational database management system (RDBMS). It i
 ## Installation
 
 ```sh
-brew install postgres
+brew install postgresql
 ```
 
 After this, we can test the installation status by checking the version of installed PostgreSQL
@@ -21,23 +21,15 @@ postgres -V
 
 ### Start PostgreSQL server
 
-```sh
-pg_ctl -D /usr/local/var/postgres start
-```
-
-Or you can start the PostgreSQL server and have it start up at login automatically
+The recommended way to manage PostgreSQL is via Homebrew services:
 
 ```sh
 brew services start postgresql
 ```
 
+This starts the server now and also sets it to start automatically at login.
+
 ### Stop PostgreSQL server
-
-```sh
-pg_ctl -D /usr/local/var/postgres stop
-```
-
-To make it stop starting up automatically at login
 
 ```sh
 brew services stop postgresql
@@ -46,27 +38,15 @@ brew services stop postgresql
 ### Restart PostgreSQL server
 
 ```sh
-pg_ctl -D /usr/local/var/postgres restart
-```
-
-Or if you're using `homebrew`
-
-```sh
 brew services restart postgresql
 ```
 
 ### Start PostgreSQL console
 
 ```sh
-psql
+psql postgres
 ```
 
 ### GUI tool
 
-We can use `psequel` a free GUI tool for managing the local and remote PostgreSQL databases
-
-Install `psequel` using `homebrew`
-
-```sh
-brew install psequel
-```
+[Postico](https://eggerapps.at/postico2/) is a popular GUI client for PostgreSQL on macOS. Alternatively, [TablePlus](https://tableplus.com/) supports PostgreSQL and many other databases.

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -3,46 +3,32 @@ title: Python
 ---
 
 
-macOS, like Linux, ships with [Python](https://python.org/) already installed.
+macOS ships with [Python](https://python.org/) already installed.
 But you don't want to mess with the system Python (some system tools rely on
 it, etc.), so we'll install our own version(s). There are two ways to install
 Python, (1) Homebrew and (2) Pyenv. If you plan to use multiple versions of
-Python (e.g. 2, 3, and anaconda) then you should use pyenv.
+Python then you should use pyenv.
 
 ## Installation
 
 ### Homebrew method
 
-Python 3 is the default version when installing with Homebrew, so if you want
-to install Python 2.7 you'll have to be explicit about it.
-
-#### Python 3
-
 ```sh
 brew install python
 ```
 
-#### Python 2.7
-
-```sh
-brew install python@2
-```
-
-Installing Python also installs [pip](https://pypi.org/project/setuptools/)
-(and its dependency [Setuptools](https://pypi.python.org/pypi/setuptools)),
+Installing Python also installs [pip](https://pip.pypa.io/)
+(and its dependency [Setuptools](https://pypi.org/project/setuptools/)),
 which is the package manager for Python. Let's upgrade them both:
 
 ```sh
-pip install --upgrade setuptools
-pip install --upgrade pip
+pip3 install --upgrade setuptools
+pip3 install --upgrade pip
 ```
-
-Executable scripts from Python packages you install will be put in
-`/usr/local/share/python`, make sure it's on your `PATH`.
 
 ### Pyenv method
 
-[`pyenv`](https://github.com/yyuu/pyenv) is a Python version manager that can
+[`pyenv`](https://github.com/pyenv/pyenv) is a Python version manager that can
 manage and install different versions of Python. Works very much like `rbenv`
 for Ruby. First, we must install `pyenv` using Homebrew:
 
@@ -51,11 +37,11 @@ brew install pyenv
 ```
 
 To upgrade `pyenv` in the future, use `upgrade` instead of `install`. After
-installing, add `pyenv init` to your shell to enable shims and autocompletion
-(use `.zshrc` if you're using `zsh`).
+installing, add `pyenv init` to your shell to enable shims and autocompletion.
+Add the following to your `~/.zshrc` (or `~/.bash_profile` if using Bash):
 
 ```sh
-echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+eval "$(pyenv init -)"
 ```
 
 Restart your shell to make sure the path changes take effect.
@@ -74,26 +60,26 @@ pyenv install --list
 Then install the desired versions:
 
 ```sh
-pyenv install 2.7.12
-pyenv install 3.5.2
+pyenv install 3.12
+pyenv install 3.11
 ```
 
 Use the `global` command to set global version(s) of Python to be used in all
-shells. For example, if you prefer 2.7.12 over 3.5.2:
+shells:
 
 ```sh
-pyenv global 2.7.12 3.5.2
+pyenv global 3.12
 pyenv rehash
 ```
 
-The leading version takes priority. All installed Python versions can be
+All installed Python versions can be
 located in `~/.pyenv/versions`. Alternatively, you can run:
 
 ```console
 $ pyenv versions
   system (set by /Users/your_account/.pyenv/version)
-* 2.7.12
-* 3.5.2
+* 3.12
+  3.11
 ```
 
 This shows an asterisk `*` next to the currently active version.
@@ -102,17 +88,13 @@ This shows an asterisk `*` next to the currently active version.
 
 The `local` command will set local application-specific Python version(s) by
 writing the version name to a `.python-version` file in the current directory.
-This version overrides the global version. For example, to install
-anaconda3-4.1.1 in `path/to/directory`:
+This version overrides the global version. For example:
 
 ```console
-$ pyenv install anaconda3-4.1.1
 $ cd path/to/directory
-$ pyenv local anaconda3-4.1.1
-$ pyenv rehash
+$ pyenv local 3.11
 $ pyenv versions
   system
-  2.7.12
-  3.5.2
-* anaconda3-4.1.1 (set by /Users/your_account/path/to/directory/.python-version)
+  3.12
+* 3.11 (set by /Users/your_account/path/to/directory/.python-version)
 ```

--- a/docs/python/pip.md
+++ b/docs/python/pip.md
@@ -3,19 +3,12 @@ title: Pip
 ---
 
 
-macOS comes with Python so there's a chance `pip` is already installed on your machine.
+[pip](https://pip.pypa.io/) is the package manager for Python. If you installed Python via Homebrew or pyenv, `pip` is already included.
 
-## Installation
-
-```console
-curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-sudo python get-pip.py
-```
-
-To verify `pip` is installed properly run
+## Verify Installation
 
 ```sh
-pip --version
+pip3 --version
 ```
 
 If it returns a version `pip` was successfully installed.
@@ -27,23 +20,23 @@ Here are a few `pip` commands to get you started.
 Install a Python package
 
 ```sh
-pip install <package>
+pip3 install <package>
 ```
 
 Upgrade a package
 
 ```sh
-pip install --upgrade <package>
+pip3 install --upgrade <package>
 ```
 
 See what's installed
 
 ```sh
-pip freeze
+pip3 freeze
 ```
 
 Uninstall a package
 
 ```sh
-pip uninstall <package>
+pip3 uninstall <package>
 ```

--- a/docs/references.md
+++ b/docs/references.md
@@ -6,10 +6,10 @@ title: References
 Thank you for all the awesome pages and documentation below which helped set this up.
 
 - [Nicolashery](https://github.com/nicolashery/mac-dev-setup)
-- [GitHub](https://help.github.com/articles)
-- [GitBook](https://github.com/GitbookIO/gitbook)
-- [Sublime Plugins](https://sublime.wbond.net/)
+- [GitHub Docs](https://docs.github.com)
+- [Docusaurus](https://docusaurus.io/)
+- [Sublime Plugins](https://packagecontrol.io/)
 
 ## Contributing
 
-Please feel free to send [Pull Requests](https://github.com/sb2nov/mac-setup/pulls) fixing any mistakes in the book or adding additional information.
+Please feel free to send [Pull Requests](https://github.com/sb2nov/mac-setup/pulls) fixing any mistakes in the guide or adding additional information.

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -27,4 +27,4 @@ To verify you can run:
 rustc --version
 ```
 
-[The official documentation on how to install Rust](https://rust-lang.org/tools/install/).
+[The official documentation on how to install Rust](https://www.rust-lang.org/tools/install).

--- a/docs/scala.md
+++ b/docs/scala.md
@@ -5,40 +5,18 @@ title: Scala
 
 Make sure you have Java installed, [the instructions are provided here](/java).
 
+## Installation
+
 ```sh
-brew update
 brew install scala sbt
 ```
 
-(This step is optional) Update the `/usr/local/etc/sbtopts` by running the command below.
+Verify the installation:
 
 ```sh
-echo '-J-XX:+CMSClassUnloadingEnabled' >> /usr/local/etc/sbtopts
-echo '-J-Xmx2G' >> /usr/local/etc/sbtopts
+scala -version
 ```
 
-## Scala Plugin for Eclipse
+## IDE Support
 
-Scala IDE for Eclipse is best installed (and updated) directly from within Eclipse.
-
-This is done by using `Help → Install New Software...`, add the `Add...` button in the dialog.
-
-Choose a name for the update site (`Scala IDE` is a suggestion). Then read the next section to select which version you will install.
-
-### What version to install
-
-The list of URLs of the different update sites are available in the download area. The release ones are in the current section. Scala IDE is linked to specific version of Scala, so you have to decide which one you are going to use:
-
-- Version `2.10`: provides support for projects using Scala 2.10 (any minor version). This is the current version of Scala. Pick this one if you are unsure.
-
-- Version `2.9`: provides support for projects using Scala 2.9 (any minor version).
-
-The version of Scala used inside of Scala IDE cannot be chosen per project. So, if you want to work with a project using different version of Scala (like 2.9.3 and 2.10.1), you need different installation of Scala IDE.
-
-### Finish installation
-
-Copy the URL as location and hit OK to validate.
-
-Select Scala IDE for Eclipse/IntelliJ from the list of available features.
-
-Finish the installation, restart Eclipse and Scala IDE is now installed.
+For Scala development, [IntelliJ IDEA](https://www.jetbrains.com/idea/) with the Scala plugin is the most popular choice. Alternatively, [VS Code](https://code.visualstudio.com/) with the [Metals](https://scalameta.org/metals/) extension provides good Scala support.

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,37 +5,31 @@ title: Security
 
 A development machine should be secured against threats as well as any other machine \(or even _especially_ a development machine\). Therefore we will setup
 
-* a virus scanner
 * a firewall
 * disk encryption
 
-## Virus Scanner
-
-Head over to [Avira](https://www.avira.com/), download and install their latest free package.
-
 ## Firewall
 
-This one is a bit controversial. If you do not install software which allows network access of any kind, skip it. If you run potentially vulnerable software you don't want to be accessed from other machines, consider turning the built-in firewall on. This particularly applies if you develop network software.
+If you run potentially vulnerable software you don't want to be accessed from other machines, consider turning the built-in firewall on. This particularly applies if you develop network software.
 
 To turn the built-in firewall on:
 
-1. Choose Apple menu \(\) &gt; System Preferences, then click Security & Privacy.
-2. Click the Firewall tab.
-3. Click the Lock button, then enter an administrator name and password.
-4. Click Turn On Firewall.
-5. Click Firewall Options.
-6. Uncheck 'Automatically allow signed software to receive incoming connections'.
+1. Choose Apple menu \(\) > System Settings, then click Network.
+2. Click Firewall.
+3. Turn on Firewall.
+4. Click Options to configure which apps are allowed incoming connections.
 
-The last step disables automatic access for software from the App Store. From now on you can either add \(dis\)allowed programs to the list within the Firewall Options or just click on Allow\/Deny, if you get a popup asking you if a specific software may be accessed.
+> **Note**: On macOS versions before Ventura, this is under System Preferences > Security & Privacy > Firewall.
 
 ## Disk Encryption
 
-Another controversial point. If you have a desktop machine in a secured building, you probably do not need disk encryption. If you travel a lot and take your notebook with you \(including all your source codes\), you might consider travelling with disk encryption enabled.
+If you travel a lot and take your notebook with you \(including all your source codes\), you should enable disk encryption.
 
 The following steps were taken from the [official apple support page](https://support.apple.com/en-us/HT204837) on this:
 
-1. Choose Apple menu \(\) &gt; System Preferences, then click Security & Privacy.
-2. Click the FileVault tab.
-3. Click the Lock button, then enter an administrator name and password.
-4. Click Turn On FileVault.
-5. Follow the instructions. In my opinion you should create a local and offline possibility to disable encryption, when you are asked how to regain access in case of anything.
+1. Choose Apple menu \(\) > System Settings, then click Privacy & Security.
+2. Scroll down to the FileVault section.
+3. Click Turn On FileVault.
+4. Follow the instructions. You should create a local and offline possibility to disable encryption, when you are asked how to regain access in case of anything.
+
+> **Note**: On newer Apple Silicon Macs, data encryption is enabled by default.

--- a/docs/system-preferences.md
+++ b/docs/system-preferences.md
@@ -1,18 +1,21 @@
 ---
-title: System Preferences
+title: System Settings
 ---
 
 ## First Time Setup
 
 The first thing you should do is update your system. To do that go:
-**Apple menu () > About This Mac > Software Update.**
+**Apple menu () > System Settings > General > Software Update.**
 
 Also upgrade your OS to the latest version to have a more secure OS. macOS
 upgrades are usually free so you might as well keep your machine up to date.
 
 If this is a new computer there are a couple tweaks you could make to the
-System Preferences. **These settings are all optional, consider them
+System Settings. **These settings are all optional, consider them
 suggestions. Always choose the setting that makes the most sense to you.**
+
+> **Note**: On macOS Ventura (13) and later, "System Preferences" has been
+> renamed to "System Settings" with a redesigned interface.
 
 ## Users & Groups
 
@@ -57,7 +60,7 @@ killall Dock # Restart the Dock process
 
 - Uncheck _fonts_, _images_, _files_ etc.
 - Uncheck the _keyboard shortcuts_ as we'll be replacing them with
-  [_Alfred_](https://www.alfredapp.com/)
+  [_Raycast_](https://www.raycast.com/)
 
 ## Accounts
 

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -3,40 +3,32 @@ title: Vagrant
 ---
 
 
-Create and configure lightweight, reproducible, and portable development environments. [Vagrant](http://www.vagrantup.com/) is a tool for managing virtual machines via a simple to use command line interface.
+Create and configure lightweight, reproducible, and portable development environments. [Vagrant](https://www.vagrantup.com/) is a tool for managing virtual machines via a simple to use command line interface.
 
-## Prerequisite
-
-You'll need `homebrew-cask`, if you don't have it refer to [this section](/homebrew/cask).
+> **Note**: For most use cases, [Docker](/docker) is now the preferred way to create
+> reproducible development environments. Vagrant is still useful when you need
+> full virtual machines.
 
 ## Installation
 
-Vagrant uses [Virtualbox](https://www.virtualbox.org/) to manage the virtual dependencies. You can [directly download virtualbox](https://www.virtualbox.org/wiki/Downloads) and install or use Homebrew for it.
-Notice that macOS High Sierra 10.13 introduces a new feature that requires user approval before loading new third-party kernel extensions.
-[In case of failure follow the instructions here](https://developer.apple.com/library/archive/technotes/tn2459/_index.html).
+Vagrant uses a virtualization provider. You can use [VirtualBox](https://www.virtualbox.org/) (free) or other providers like VMware or Parallels.
 
 ```sh
 brew install --cask virtualbox
 ```
 
-Now install Vagrant either [from the website](http://www.vagrantup.com/downloads.html) or use Homebrew for installing it.
+Now install Vagrant:
 
 ```sh
 brew install --cask vagrant
 ```
 
-[Vagrant-Manager](http://vagrantmanager.com/) helps you manage all your virtual machines in one place directly from the menu bar.
-
-```sh
-brew install --cask vagrant-manager
-```
-
 ## Usage
 
-Add the Vagrant box you want to use. We'll use Ubuntu 12.04 for the following example.
+Add the Vagrant box you want to use. We'll use Ubuntu 22.04 for the following example.
 
 ```sh
-vagrant box add precise64 https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box
+vagrant box add ubuntu/jammy64
 ```
 
 You can find more boxes at [Vagrant Cloud](https://app.vagrantup.com/boxes/search).
@@ -44,7 +36,7 @@ You can find more boxes at [Vagrant Cloud](https://app.vagrantup.com/boxes/searc
 Now create a test directory and `cd` into the test directory. Then we'll initialize the vagrant machine.
 
 ```sh
-vagrant init precise64
+vagrant init ubuntu/jammy64
 ```
 
 Now lets start the machine using the following command.

--- a/docs/xcode.md
+++ b/docs/xcode.md
@@ -17,4 +17,8 @@ It'll prompt you to install the command line tools. Follow the instructions and 
 
 ## XQuartz
 
-XQuartz is Apple Inc.'s version of the X server, a component of the X Window System for macOS. It might be useful if you are developing software for macOS, [it's available for download here](http://xquartz.macosforge.org/landing/).
+XQuartz is Apple Inc.'s version of the X server, a component of the X Window System for macOS. It might be useful if you are developing software that uses X11, [it's available for download here](https://www.xquartz.org/) or via Homebrew:
+
+```sh
+brew install --cask xquartz
+```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -102,7 +102,7 @@ const config: Config = {
           title: 'Guide',
           items: [
             {
-              label: 'System Preferences',
+              label: 'System Settings',
               to: '/system-preferences',
             },
             {


### PR DESCRIPTION
## Changes

- Fixed broken Docusaurus link (removed double slash)
- Updated 1Password link from agilebits.com to 1password.com
- Updated documentation URLs for GitHub (help.github.com → docs.github.com)
- Updated Go website links (golang.org → go.dev)
- Updated Octave link (gnu.org → octave.org)
- Updated Doom Emacs repository and installation instructions
- Updated SSH key generation to use ed25519 instead of rsa
- Updated bash-completion installation to use bash-completion@2
- Modernized Go, Docker, Python, and Java documentation
- Reorganized apps list with new categories (AI Tools, Communication)
- Added new tools: Raycast, Warp, Cursor, Zed, GitHub Desktop, Shottr
- Updated Homebrew installation instructions for Apple Silicon support
- Improved PostgreSQL and Java installation documentation
- Removed obsolete apps and deprecated instructions
- Updated various Homebrew paths for cross-platform compatibility